### PR TITLE
Selection and blend mode enhancements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1373,9 +1373,9 @@
       }
     },
     "node_modules/async": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-      "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
       "dev": true,
       "dependencies": {
         "lodash": "^4.17.14"
@@ -8353,9 +8353,9 @@
       "dev": true
     },
     "async": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-      "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
       "dev": true,
       "requires": {
         "lodash": "^4.17.14"

--- a/src/demo/debugging-demo.ts
+++ b/src/demo/debugging-demo.ts
@@ -107,6 +107,7 @@ async function main() {
     randomize: false,
     showText: false,
     mouseover: false,
+    clearBeforeUpdate: false,
   };
 
   const colors = d3.schemeCategory10;
@@ -123,6 +124,10 @@ async function main() {
 
   // Function to call when GUI options are changed.
   function update() {
+    if (settings.clearBeforeUpdate) {
+      selection.clear();
+    }
+
     const count = settings.count;
     settings.total = count * count;
 
@@ -222,6 +227,7 @@ async function main() {
   gui.add(settings, 'randomize').onChange(update);
   gui.add(settings, 'showText').onChange(update);
   gui.add(settings, 'mouseover');
+  gui.add(settings, 'clearBeforeUpdate');
   update();
   container.appendChild(gui.domElement);
 

--- a/src/demo/text-demo.ts
+++ b/src/demo/text-demo.ts
@@ -83,6 +83,7 @@ async function main() {
     facet: 'type',
     borderColor: '#000000',
     fillColor: '#ffffff',
+    clearBeforeUpdate: false,
   };
 
   // As a synthetic data set, use the properties on the Window object.
@@ -120,6 +121,10 @@ async function main() {
 
   // Function to call when GUI options are changed.
   function update() {
+    if (settings.clearBeforeUpdate) {
+      textSelection.clear();
+    }
+
     const facets = new Map<string, Label[]>();
 
     for (const label of labels) {
@@ -220,6 +225,7 @@ async function main() {
   gui.add(settings, 'facet', ['type', 'alpha']).onChange(update);
   gui.addColor(settings, 'borderColor').onChange(update);
   gui.addColor(settings, 'fillColor').onChange(update);
+  gui.add(settings, 'clearBeforeUpdate');
   update();
   container.appendChild(gui.domElement);
 

--- a/src/lib/commands/setup-draw-command.ts
+++ b/src/lib/commands/setup-draw-command.ts
@@ -66,8 +66,9 @@ export function setupDrawCommand(
       },
       equation: {
         rgb: 'add',
-        alpha: 'max',
+        alpha: 'add',
       },
+      color: [0, 0, 0, 0]
     },
 
     frag: fragmentShader(),

--- a/src/lib/scene-internal.ts
+++ b/src/lib/scene-internal.ts
@@ -387,8 +387,8 @@ export class SceneInternal implements Renderer {
     // Look for either the REGL module or createREGL global since both are
     // supported. The latter is for hot-loading the standalone Regl JS file.
     const win = window as {} as {[key: string]: unknown};
-    const createREGL =
-        win['createREGL']! as (...args: unknown[]) => REGL.Regl || REGL;
+    const createREGL = win['createREGL']! as (...args: unknown[]) =>
+                           REGL.Regl || REGL;
 
     if (!createREGL) {
       throw new Error('Could not find REGL.');
@@ -398,7 +398,7 @@ export class SceneInternal implements Renderer {
       container: this.container,
       extensions: [
         'angle_instanced_arrays',
-        'EXT_blend_minmax',
+        //'EXT_blend_minmax',
         'OES_texture_float',
         'OES_texture_float_linear',
       ],

--- a/src/lib/scene-internal.ts
+++ b/src/lib/scene-internal.ts
@@ -398,7 +398,6 @@ export class SceneInternal implements Renderer {
       container: this.container,
       extensions: [
         'angle_instanced_arrays',
-        //'EXT_blend_minmax',
         'OES_texture_float',
         'OES_texture_float_linear',
       ],

--- a/src/lib/selection-impl.ts
+++ b/src/lib/selection-impl.ts
@@ -120,7 +120,7 @@ export class SelectionImpl<T> implements Selection<T> {
     if (this.clearingTask) {
       this.workScheduler.scheduleUniqueTask({
         id: this.bindingTaskId,
-        callback: () => this.bind(data),
+        callback: () => this.bind(data, keyFn),
       });
       return this;
     }
@@ -384,15 +384,8 @@ export class SelectionImpl<T> implements Selection<T> {
       this.boundData.splice(0, index);
       this.sprites.splice(0, index);
 
-      if (!this.boundData.length) {
-        // Finally finished clearing data, so we no longer need the
-        // clearingTask.
-        delete this.clearingTask;
-        return true;
-      }
-
-      // Still more clearing to do.
-      return false;
+      // Return whether there's more data to clear.
+      return !this.boundData.length;
     };
 
     // Define a clearing task which will be invoked by the WorkScheduler to

--- a/src/lib/selection-impl.ts
+++ b/src/lib/selection-impl.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 /**
- * @fileoverview Implements the Selection API for SceneImpl.
+ * @fileoverview Implements the Selection API.
  */
 
 import {Renderer} from './renderer-types';

--- a/src/lib/selection-types.d.ts
+++ b/src/lib/selection-types.d.ts
@@ -71,4 +71,13 @@ export interface Selection<T> {
    * key string produced.
    */
   bind: (data: T[], keyFn?: (datum: T) => string) => Selection<T>;
+
+  /**
+   * Clear any previously bound data and Sprites. Previously bound Sprites will
+   * still have their callbacks invoked. This is equivalent to calling bind()
+   * with an empty array, except that it is guaranteed to drop expsting data and
+   * Sprites, whereas calling bind([]) may be interrupted by a later call to
+   * bind().
+   */
+  clear: () => Selection<T>;
 }

--- a/src/lib/text-selection-impl.ts
+++ b/src/lib/text-selection-impl.ts
@@ -296,30 +296,6 @@ export class TextSelectionImpl<T> implements TextSelection<T> {
 
       return dataLength >= this.boundData.length;
     };
-    /*
-    const exitTask = (remaining: RemainingTimeFn) => {
-      let index = dataLength;
-
-      while (index < this.boundData.length) {
-        step++;
-
-        const selection = this.selections[index];
-
-        index++;
-
-        selection.bind([]);
-
-        if (step % this.stepsBetweenChecks === 0 && remaining() <= 0) {
-          break;
-        }
-      }
-
-      this.boundData.splice(dataLength, index - dataLength);
-      this.selections.splice(dataLength, index - dataLength);
-
-      return index < this.boundData.length;
-    };
-    */
 
     // Perform one unit of work, starting with any exit tasks, then updates,
     // then enter tasks. This way, previously used texture memory can be

--- a/src/lib/text-selection-impl.ts
+++ b/src/lib/text-selection-impl.ts
@@ -286,4 +286,9 @@ export class TextSelectionImpl<T> implements TextSelection<T> {
 
     return this;
   }
+
+  clear() {
+    throw new Error('clear() not yet implemented');
+    return this;
+  }
 }


### PR DESCRIPTION
- Adds `Selection::clear()` to schedule all previously bound data/sprites to be removed. #11
- Warns the API user (up to once per Selection) if multiple `bind()` calls are received while a previous bind was scheduled. #12
- Fix blend mode to be default add instead of max. Addresses but does not fully fix #9
- Adds unit tests for `Selection::clear()` and adds an option to demos to invoke `clear()` on each change.
- Fix bug where rendering would end one frame too early for especially short transition times.
- Updates npm dependencies.