### PR TITLE
Enable no-confusing-void-expression ESLint TypeScript rule

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -40,6 +40,7 @@ module.exports = {
     tsconfigRootDir:__dirname,
   },
   rules: {
+    '@typescript-eslint/no-confusing-void-expression': ERROR,
     '@typescript-eslint/prefer-readonly': ERROR,
   },
 };

--- a/src/lib/scene-internal.ts
+++ b/src/lib/scene-internal.ts
@@ -952,8 +952,9 @@ export class SceneInternal implements Renderer {
    * This method schedules runCallbacks to be invoked if it isn't already.
    */
   queueRunCallbacks() {
-    const runMethod = (remaining: RemainingTimeFn) =>
-        runCallbacks(this, remaining, STEPS_BETWEEN_REMAINING_TIME_CHECKS);
+    const runMethod = (remaining: RemainingTimeFn) => {
+      runCallbacks(this, remaining, STEPS_BETWEEN_REMAINING_TIME_CHECKS);
+    };
     this.queueTask(this.runCallbacksTaskId, runMethod);
   }
 
@@ -965,13 +966,16 @@ export class SceneInternal implements Renderer {
    * that the sprite used to command can be reused for another sprite later.
    */
   queueRemovalTask() {
-    const runMethod = (remaining: RemainingTimeFn) =>
-        runRemoval(this, remaining, STEPS_BETWEEN_REMAINING_TIME_CHECKS);
+    const runMethod = (remaining: RemainingTimeFn) => {
+      runRemoval(this, remaining, STEPS_BETWEEN_REMAINING_TIME_CHECKS);
+    };
     this.queueTask(this.runRemovalTaskId, runMethod);
   }
 
   queueTextureSync() {
-    this.queueTask(this.textureSyncTaskId, () => runTextureSync(this));
+    this.queueTask(this.textureSyncTaskId, () => {
+      runTextureSync(this);
+    });
   }
 
   createSelection<T>(): Selection<T> {

--- a/src/lib/scene-internal.ts
+++ b/src/lib/scene-internal.ts
@@ -703,7 +703,9 @@ export class SceneInternal implements Renderer {
   }
 
   queueDraw(beginImmediately = true) {
-    this.queueTask(this.drawTaskId, () => this.doDraw(), beginImmediately);
+    this.queueTask(this.drawTaskId, () => {
+      this.doDraw();
+    }, beginImmediately);
   }
 
   /**
@@ -713,7 +715,9 @@ export class SceneInternal implements Renderer {
   async snapshot(): Promise<Blob> {
     this.drawCommand();
     return new Promise((resolve, reject) => {
-      this.canvas.toBlob(blob => blob ? resolve(blob) : reject(blob));
+      this.canvas.toBlob(blob => {
+        blob ? resolve(blob) : reject(blob);
+      });
     });
   }
 
@@ -928,7 +932,9 @@ export class SceneInternal implements Renderer {
   }
 
   queueRebase() {
-    this.queueTask(this.rebaseTaskId, () => runRebase(this));
+    this.queueTask(this.rebaseTaskId, () => {
+      runRebase(this);
+    });
   }
 
   /**
@@ -936,8 +942,9 @@ export class SceneInternal implements Renderer {
    * It uses available swatch capacity to take waiting sprites out of the queue.
    */
   queueAssignWaiting() {
-    const runMethod = (remaining: RemainingTimeFn) =>
-        runAssignWaiting(this, remaining, STEPS_BETWEEN_REMAINING_TIME_CHECKS);
+    const runMethod = (remaining: RemainingTimeFn) => {
+      runAssignWaiting(this, remaining, STEPS_BETWEEN_REMAINING_TIME_CHECKS);
+    };
     this.queueTask(this.runAssignWaitingTaskId, runMethod);
   }
 

--- a/src/lib/tasks/run-assign-waiting.ts
+++ b/src/lib/tasks/run-assign-waiting.ts
@@ -60,7 +60,7 @@ export function runAssignWaiting(
     coordinator: CoordinatorAPI,
     remaining: RemainingTimeFn,
     stepsBetweenChecks: number,
-) {
+    ): void {
   const {
     removedIndexRange,
     sprites,
@@ -153,10 +153,7 @@ export function runAssignWaiting(
       throw new InternalError('Removed Sprite lacks index');
     }
 
-    coordinator.assignSpriteToIndex(
-        waitingSprite,
-        removedProperties.index,
-    );
+    coordinator.assignSpriteToIndex(waitingSprite, removedProperties.index);
 
     if (waitingProperties.index === undefined) {
       throw new InternalError('Sprite index was not assigned');

--- a/src/lib/tasks/run-callbacks.ts
+++ b/src/lib/tasks/run-callbacks.ts
@@ -66,7 +66,7 @@ export function runCallbacks(
     coordinator: CoordinatorAPI,
     remaining: RemainingTimeFn,
     stepsBetweenChecks: number,
-) {
+    ): void {
   if (!coordinator.callbacksIndexRange.isDefined) {
     // This indicates a timing error in the code.
     throw new InternalError('Running callbacks requires a range of indices');
@@ -261,7 +261,4 @@ export function runCallbacks(
       coordinator.queueDraw();
     }
   }
-
-  // We're done with this task.
-  return true;
 }

--- a/src/lib/tasks/run-hit-test.ts
+++ b/src/lib/tasks/run-hit-test.ts
@@ -53,7 +53,7 @@ interface CoordinatorAPI {
  */
 export function runHitTest(
     coordinator: CoordinatorAPI,
-) {
+    ): void {
   // These values are API-user provided, but are already be checked for
   // correctness upstream in SceneInternal.
   const {sprites, width, height, inclusive} = coordinator.hitTestParameters;

--- a/src/lib/tasks/run-hit-test.ts
+++ b/src/lib/tasks/run-hit-test.ts
@@ -51,9 +51,7 @@ interface CoordinatorAPI {
  *
  * @param coordinator Upstream object upon which this task operates.
  */
-export function runHitTest(
-    coordinator: CoordinatorAPI,
-    ): void {
+export function runHitTest(coordinator: CoordinatorAPI): void {
   // These values are API-user provided, but are already be checked for
   // correctness upstream in SceneInternal.
   const {sprites, width, height, inclusive} = coordinator.hitTestParameters;

--- a/src/lib/tasks/run-rebase.ts
+++ b/src/lib/tasks/run-rebase.ts
@@ -50,10 +50,8 @@ interface CoordinatorAPI {
  *
  * @param coordinator Upstream object upon which this task operates.
  */
-export function runRebase(
-    coordinator: CoordinatorAPI,
-    ): void {
-  // Sanity check: nothing to do if there's nothing in the rebase queue.
+export function runRebase(coordinator: CoordinatorAPI): void {
+  // Sanity check: nothing to do if the rebase index range is empty.
   if (!coordinator.needsRebaseIndexRange.isDefined) {
     throw new InternalError('No sprites are queued for rebase');
   }

--- a/src/lib/tasks/run-rebase.ts
+++ b/src/lib/tasks/run-rebase.ts
@@ -52,7 +52,7 @@ interface CoordinatorAPI {
  */
 export function runRebase(
     coordinator: CoordinatorAPI,
-) {
+    ): void {
   // Sanity check: nothing to do if there's nothing in the rebase queue.
   if (!coordinator.needsRebaseIndexRange.isDefined) {
     throw new InternalError('No sprites are queued for rebase');

--- a/src/lib/tasks/run-removal.ts
+++ b/src/lib/tasks/run-removal.ts
@@ -58,7 +58,7 @@ export function runRemoval(
     coordinator: CoordinatorAPI,
     remaining: RemainingTimeFn,
     stepsBetweenChecks: number,
-) {
+    ): void {
   if (!coordinator.toBeRemovedIndexRange.isDefined ||
       !coordinator.toBeRemovedTsRange.isDefined) {
     // This signals an error in lifecycle phase change logic of the coordinator.
@@ -75,7 +75,7 @@ export function runRemoval(
   // their target times. If not, then we queue a future removal task.
   if (currentTimeMs < lowTs) {
     coordinator.queueRemovalTask();
-    return true;
+    return;
   }
 
   const {lowBound: lowIndex, highBound: highIndex} =
@@ -168,6 +168,4 @@ export function runRemoval(
       coordinator.queueRemovalTask();
     }
   }
-
-  return true;
 }

--- a/src/lib/tasks/run-texture-sync.ts
+++ b/src/lib/tasks/run-texture-sync.ts
@@ -78,7 +78,7 @@ function getSwatchRowExpandedRange(
 /**
  * Iterate through the Sprites and push data into the data texture.
  */
-export function runTextureSync(coordinator: CoordinatorAPI) {
+export function runTextureSync(coordinator: CoordinatorAPI): void {
   // Short-circuit of there are no dirty indices to update.
   if (!coordinator.needsTextureSyncIndexRange.isDefined) {
     throw new InternalError('No sprites are in need of texture sync');
@@ -105,7 +105,7 @@ export function runTextureSync(coordinator: CoordinatorAPI) {
       // rebase operation, and then make another attempt at texture sync.
       coordinator.queueRebase();
       coordinator.queueTextureSync();
-      return true;
+      return;
     }
   }
 
@@ -217,6 +217,4 @@ export function runTextureSync(coordinator: CoordinatorAPI) {
     height: rowHeight,
   };
   coordinator.targetValuesTexture.subimage(subimageData, 0, lowRow);
-
-  return true;
 }

--- a/src/lib/timing-functions-shim.ts
+++ b/src/lib/timing-functions-shim.ts
@@ -149,7 +149,7 @@ export class TimingFunctionsShim implements TimingFunctions {
     this.cancelAnimationFrame = function cancelAnimationFrame(
         this: unknown, id: number): void {
       checkThis(this);
-      return boundCancelAnimationFrame(id);
+      boundCancelAnimationFrame(id);
     };
 
     const boundSetTimeout = this.setTimeout.bind(this);
@@ -163,7 +163,7 @@ export class TimingFunctionsShim implements TimingFunctions {
     const boundClearTimeout = this.clearTimeout.bind(this);
     this.clearTimeout = function clearTimeout(this: unknown, id: number): void {
       checkThis(this);
-      return boundClearTimeout(id);
+      boundClearTimeout(id);
     };
 
     /**


### PR DESCRIPTION
Enable `no-confusing-void-expression` rule and code changes to satisfy, per #23.