### PR TITLE
Make `HitTestParameters.sprites` readonly

### DIFF
--- a/src/lib/hit-test-types.d.ts
+++ b/src/lib/hit-test-types.d.ts
@@ -27,7 +27,7 @@ export interface HitTestParameters {
   /**
    * List of candidate sprites to test.
    */
-  sprites: Sprite[];
+  sprites: readonly Sprite[];
 
   /**
    * X coordinate in pixels relative to the renderable area (canvas) of the


### PR DESCRIPTION
Per the discussion on #26, this change makes`HitTestParameters.sprites` `readonly Sprite[]` rather than `Sprite[]`.

Tested as follows, but let me know if some other form of testing is appropriate:

```
$ npm test                                                                                                                                                                                             ⬡ 16.15.1 [±dev ✓]

> megaplot@0.1.2 test
> karma start karma.conf.ts

webpack was not included as a framework in karma configuration, setting this automatically...
Webpack bundling...
Webpack starts watching...
...
webpack 5.27.2 compiled successfully in 7752 ms
26 06 2022 16:20:16.832:WARN [karma]: No captured browser, open http://localhost:9876/
26 06 2022 16:20:16.852:INFO [karma-server]: Karma v6.3.17 server started at http://localhost:9876/
26 06 2022 16:20:23.291:INFO [Chrome 103.0.0.0 (Mac OS 10.15.7)]: Connected on socket QqMQXNVZEfDdZG6VAAAB with id manual-2158
Chrome 103.0.0.0 (Mac OS 10.15.7): Executed 110 of 110 SUCCESS (1.837 secs / 1.743 secs)
TOTAL: 110 SUCCESS
```

