### PR TITLE
Implement OrderZ sprite attribute.

### DIFF
--- a/src/demo/debugging-demo.ts
+++ b/src/demo/debugging-demo.ts
@@ -107,6 +107,7 @@ function main() {
     maxSizePxHeight: 0,
     minSizePxWidth: 0,
     minSizePxHeight: 0,
+    flipZ: false,
     randomize: false,
     showText: false,
     hitTestOnMove: false,
@@ -174,6 +175,8 @@ function main() {
       s.PositionPixelY = -Math.floor(3 * j / count) * settings.paddingPx;
       s.PositionRelativeX = settings.positionRelative;
 
+      s.OrderZ = settings.flipZ ? (settings.total - index) / settings.total : 0;
+
       s.GeometricZoom = settings.geometricZoom;
 
       s.SizeWorld = 1 / count * settings.sizeMultiplier;
@@ -234,6 +237,7 @@ function main() {
   gui.add(settings, 'maxSizePxHeight', 0, 400, 10).onChange(update);
   gui.add(settings, 'minSizePxWidth', 0, 400, 10).onChange(update);
   gui.add(settings, 'minSizePxHeight', 0, 400, 10).onChange(update);
+  gui.add(settings, 'flipZ').onChange(update);
   gui.add(settings, 'randomize').onChange(update);
   gui.add(settings, 'showText').onChange(update);
   gui.add(settings, 'hitTestOnMove');

--- a/src/demo/debugging-demo.ts
+++ b/src/demo/debugging-demo.ts
@@ -180,7 +180,10 @@ function main() {
       s.PositionPixelY = -Math.floor(3 * j / count) * settings.paddingPx;
       s.PositionRelativeX = settings.positionRelative;
 
-      // s.OrderZ = settings.flipZ ? 1 : 0;
+      s.OrderZ = 0;
+      if (settings.flipZ && index < settings.total) {
+        s.OrderZ = (settings.total - index) / settings.total;
+      }
 
       s.GeometricZoom = settings.geometricZoom;
 

--- a/src/demo/debugging-demo.ts
+++ b/src/demo/debugging-demo.ts
@@ -107,6 +107,7 @@ function main() {
     maxSizePxHeight: 0,
     minSizePxWidth: 0,
     minSizePxHeight: 0,
+    staggerAnimation: true,
     flipZ: false,
     randomize: false,
     showText: false,
@@ -154,7 +155,15 @@ function main() {
     });
 
     selection.onBind((s, index) => {
+      if (index > settings.total - 1) {
+        // This sprite is about to exit.
+        return;
+      }
+
       s.TransitionTimeMs = settings.transitionTimeMs;
+      if (settings.staggerAnimation) {
+        s.TransitionTimeMs *= (1 + index) / settings.total;
+      }
 
       const i = index % count;
       const j = Math.floor(index / count);
@@ -175,7 +184,7 @@ function main() {
       s.PositionPixelY = -Math.floor(3 * j / count) * settings.paddingPx;
       s.PositionRelativeX = settings.positionRelative;
 
-      s.OrderZ = settings.flipZ ? (settings.total - index) / settings.total : 0;
+      // s.OrderZ = settings.flipZ ? 1 : 0;
 
       s.GeometricZoom = settings.geometricZoom;
 
@@ -237,6 +246,7 @@ function main() {
   gui.add(settings, 'maxSizePxHeight', 0, 400, 10).onChange(update);
   gui.add(settings, 'minSizePxWidth', 0, 400, 10).onChange(update);
   gui.add(settings, 'minSizePxHeight', 0, 400, 10).onChange(update);
+  gui.add(settings, 'staggerAnimation');
   gui.add(settings, 'flipZ').onChange(update);
   gui.add(settings, 'randomize').onChange(update);
   gui.add(settings, 'showText').onChange(update);

--- a/src/demo/debugging-demo.ts
+++ b/src/demo/debugging-demo.ts
@@ -144,24 +144,20 @@ function main() {
     const colorScale = d3.scaleLinear(colors).domain(
         d3.range(0, count * count, count * count / colors.length));
 
-    selection.onInit(s => {
+    selection.onInit((s) => {
       s.BorderColorOpacity = 0;
       s.FillColorOpacity = 0;
     });
 
-    selection.onExit(s => {
+    selection.onExit((s) => {
       s.BorderColorOpacity = 0;
       s.FillColorOpacity = 0;
     });
 
     selection.onBind((s, index) => {
-      if (index > settings.total - 1) {
-        // This sprite is about to exit.
-        return;
-      }
-
       s.TransitionTimeMs = settings.transitionTimeMs;
-      if (settings.staggerAnimation) {
+
+      if (settings.staggerAnimation && index < settings.total) {
         s.TransitionTimeMs *= (1 + index) / settings.total;
       }
 

--- a/src/lib/attribute-mapper.ts
+++ b/src/lib/attribute-mapper.ts
@@ -19,7 +19,7 @@
  * to a data texture.
  */
 
-import {SPRITE_ATTRIBUTES} from './sprite-attributes';
+import {SPRITE_ATTRIBUTES, SpriteAttribute} from './sprite-attributes';
 
 const RGBA = Object.freeze(['r', 'g', 'b', 'a']);
 
@@ -91,10 +91,18 @@ export class AttributeMapper {
   public readonly attributeComponentNames: string[];
 
   /**
-   * Object, frozen on construction, that maps attribute names to their indices.
+   * Object, frozen on construction, that maps attribute component names to
+   * their indices.
    */
   public readonly attributeComponentIndices:
       {[attributeComponentName: string]: number};
+
+  /**
+   * Object, frozen on construction, that maps each full attribute component
+   * name back to the attribute that created it.
+   */
+  public readonly componentToAttributeMap:
+      {[attributeComponentName: string]: SpriteAttribute};
 
   /**
    * Number of texels in one swatch of the data texture. A swatch has enough
@@ -185,9 +193,9 @@ export class AttributeMapper {
     this.desiredSwatchCapacity = settings.desiredSwatchCapacity;
     this.attributes = settings.attributes;
 
-    this.attributeComponentIndices = {} as
-        {[attributeComponentName: string]: number};
+    this.attributeComponentIndices = {};
     this.attributeComponentNames = [];
+    this.componentToAttributeMap = {};
     this.isAttributeTimestamp = [];
 
     // Copy attribute component names into local array and create lookup index.
@@ -202,6 +210,7 @@ export class AttributeMapper {
         const index = this.attributeComponentNames.length;
         this.attributeComponentNames[index] = attributeComponentName;
         this.attributeComponentIndices[attributeComponentName] = index;
+        this.componentToAttributeMap[attributeComponentName] = attribute;
         this.isAttributeTimestamp[index] = !!attribute.isTimestamp;
       }
     }

--- a/src/lib/commands/setup-draw-command.ts
+++ b/src/lib/commands/setup-draw-command.ts
@@ -110,6 +110,7 @@ export function setupDrawCommand(
     'uniforms': {
       'ts': () => coordinator.elapsedTimeMs(),
       'instanceCount': () => coordinator.instanceCount,
+      'orderZGranularity': () => 10,
       'viewMatrix': () => coordinator.getViewMatrix(),
       'viewMatrixScale': () => coordinator.getViewMatrixScale(),
       'projectionMatrix': (context: REGL.DefaultContext) => {

--- a/src/lib/commands/setup-draw-command.ts
+++ b/src/lib/commands/setup-draw-command.ts
@@ -109,7 +109,7 @@ export function setupDrawCommand(
 
     'uniforms': {
       'ts': () => coordinator.elapsedTimeMs(),
-      'instanceZ': () => 1 / (1 + coordinator.instanceCount),
+      'instanceCount': () => coordinator.instanceCount,
       'viewMatrix': () => coordinator.getViewMatrix(),
       'viewMatrixScale': () => coordinator.getViewMatrixScale(),
       'projectionMatrix': (context: REGL.DefaultContext) => {

--- a/src/lib/commands/setup-draw-command.ts
+++ b/src/lib/commands/setup-draw-command.ts
@@ -40,6 +40,7 @@ interface CoordinatorAPI {
   instanceCount: number;
   instanceIndexBuffer: REGL.Buffer;
   instanceSwatchUvBuffer: REGL.Buffer;
+  orderZGranularity: number;
   previousValuesFramebuffer: REGL.Framebuffer2D;
   regl: REGL.Regl;
   sdfTexture: REGL.Texture;
@@ -110,7 +111,7 @@ export function setupDrawCommand(
     'uniforms': {
       'ts': () => coordinator.elapsedTimeMs(),
       'instanceCount': () => coordinator.instanceCount,
-      'orderZGranularity': () => 10,
+      'orderZGranularity': () => coordinator.orderZGranularity,
       'viewMatrix': () => coordinator.getViewMatrix(),
       'viewMatrixScale': () => coordinator.getViewMatrixScale(),
       'projectionMatrix': (context: REGL.DefaultContext) => {

--- a/src/lib/default-scene-settings.ts
+++ b/src/lib/default-scene-settings.ts
@@ -32,13 +32,14 @@ export const DEFAULT_GLYPHS =
 /**
  * Parameters to configure the Scene.
  */
-export const DEFAULT_SCENE_SETTINGS = Object.freeze({
+export const DEFAULT_SCENE_SETTINGS: SceneSettings = Object.freeze({
   container: document.body,
   defaultTransitionTimeMs: 250,
-  glyphs: DEFAULT_GLYPHS,
   desiredSpriteCapacity: 1e6,
-  timingFunctions: DEFAULT_TIMING_FUNCTIONS,
+  glyphs: DEFAULT_GLYPHS,
   glyphMapper: DEFAULT_GLYPH_MAPPER_SETTINGS,
+  orderZGranularity: 10,
+  timingFunctions: DEFAULT_TIMING_FUNCTIONS,
 });
 
 /**
@@ -57,6 +58,9 @@ export const DEFAULT_SCENE_SETTINGS = Object.freeze({
  *     fire for the datum and its associated SpriteView.
  * @param {string} glyphs Characters to support in glyph mapper.
  * @param {GlyphMapperSettings} glyphMapper Settings for the glyph mapper.
+ * @param {number} orderZGranularity Granularity of OrderZ values. Higher means
+ *     more granular control over user-specified OrderZ, but reduces precision
+ *     remaining for differentiating stacked sprites with the same OrderZ.
  * @param {TimingFunctions} timingFunctions Timing functions for WorkScheduler.
  */
 export interface SceneSettings {
@@ -65,5 +69,6 @@ export interface SceneSettings {
   desiredSpriteCapacity: number;
   glyphs: string;
   glyphMapper: GlyphMapperSettings;
+  orderZGranularity: number;
   timingFunctions: TimingFunctions;
 }

--- a/src/lib/generated/sprite-view-impl.ts
+++ b/src/lib/generated/sprite-view-impl.ts
@@ -37,6 +37,7 @@ export class SpriteViewImpl implements SpriteView {
     if (isNaN(attributeValue)) {
       throw new RangeError('TransitionTimeMs cannot be NaN');
     }
+
     this[DataViewSymbol][0] = attributeValue;
   }
 
@@ -48,6 +49,7 @@ export class SpriteViewImpl implements SpriteView {
     if (isNaN(attributeValue)) {
       throw new RangeError('PositionWorldX cannot be NaN');
     }
+
     this[DataViewSymbol][1] = attributeValue;
   }
 
@@ -59,6 +61,7 @@ export class SpriteViewImpl implements SpriteView {
     if (isNaN(attributeValue)) {
       throw new RangeError('PositionWorldY cannot be NaN');
     }
+
     this[DataViewSymbol][2] = attributeValue;
   }
 
@@ -70,6 +73,7 @@ export class SpriteViewImpl implements SpriteView {
     if (isNaN(attributeValue)) {
       throw new RangeError('SizeWorldWidth cannot be NaN');
     }
+
     this[DataViewSymbol][3] = attributeValue;
   }
 
@@ -81,370 +85,424 @@ export class SpriteViewImpl implements SpriteView {
     if (isNaN(attributeValue)) {
       throw new RangeError('SizeWorldHeight cannot be NaN');
     }
+
     this[DataViewSymbol][4] = attributeValue;
   }
 
-  get GeometricZoomX(): number {
+  get OrderZ(): number {
     return this[DataViewSymbol][5];
+  }
+
+  set OrderZ(attributeValue: number) {
+    if (isNaN(attributeValue)) {
+      throw new RangeError('OrderZ cannot be NaN');
+    }
+
+    if (attributeValue < 0) {
+      throw new RangeError('OrderZ cannot be less than 0');
+    }
+
+    if (attributeValue > 1) {
+      throw new RangeError('OrderZ cannot be greater than 1');
+    }
+
+    this[DataViewSymbol][5] = attributeValue;
+  }
+
+  get GeometricZoomX(): number {
+    return this[DataViewSymbol][6];
   }
 
   set GeometricZoomX(attributeValue: number) {
     if (isNaN(attributeValue)) {
       throw new RangeError('GeometricZoomX cannot be NaN');
     }
-    this[DataViewSymbol][5] = attributeValue;
+
+    this[DataViewSymbol][6] = attributeValue;
   }
 
   get GeometricZoomY(): number {
-    return this[DataViewSymbol][6];
+    return this[DataViewSymbol][7];
   }
 
   set GeometricZoomY(attributeValue: number) {
     if (isNaN(attributeValue)) {
       throw new RangeError('GeometricZoomY cannot be NaN');
     }
-    this[DataViewSymbol][6] = attributeValue;
+
+    this[DataViewSymbol][7] = attributeValue;
   }
 
   get PositionPixelX(): number {
-    return this[DataViewSymbol][7];
+    return this[DataViewSymbol][8];
   }
 
   set PositionPixelX(attributeValue: number) {
     if (isNaN(attributeValue)) {
       throw new RangeError('PositionPixelX cannot be NaN');
     }
-    this[DataViewSymbol][7] = attributeValue;
+
+    this[DataViewSymbol][8] = attributeValue;
   }
 
   get PositionPixelY(): number {
-    return this[DataViewSymbol][8];
+    return this[DataViewSymbol][9];
   }
 
   set PositionPixelY(attributeValue: number) {
     if (isNaN(attributeValue)) {
       throw new RangeError('PositionPixelY cannot be NaN');
     }
-    this[DataViewSymbol][8] = attributeValue;
+
+    this[DataViewSymbol][9] = attributeValue;
   }
 
   get SizePixelWidth(): number {
-    return this[DataViewSymbol][9];
+    return this[DataViewSymbol][10];
   }
 
   set SizePixelWidth(attributeValue: number) {
     if (isNaN(attributeValue)) {
       throw new RangeError('SizePixelWidth cannot be NaN');
     }
-    this[DataViewSymbol][9] = attributeValue;
+
+    this[DataViewSymbol][10] = attributeValue;
   }
 
   get SizePixelHeight(): number {
-    return this[DataViewSymbol][10];
+    return this[DataViewSymbol][11];
   }
 
   set SizePixelHeight(attributeValue: number) {
     if (isNaN(attributeValue)) {
       throw new RangeError('SizePixelHeight cannot be NaN');
     }
-    this[DataViewSymbol][10] = attributeValue;
+
+    this[DataViewSymbol][11] = attributeValue;
   }
 
   get MaxSizePixelWidth(): number {
-    return this[DataViewSymbol][11];
+    return this[DataViewSymbol][12];
   }
 
   set MaxSizePixelWidth(attributeValue: number) {
     if (isNaN(attributeValue)) {
       throw new RangeError('MaxSizePixelWidth cannot be NaN');
     }
-    this[DataViewSymbol][11] = attributeValue;
+
+    this[DataViewSymbol][12] = attributeValue;
   }
 
   get MaxSizePixelHeight(): number {
-    return this[DataViewSymbol][12];
+    return this[DataViewSymbol][13];
   }
 
   set MaxSizePixelHeight(attributeValue: number) {
     if (isNaN(attributeValue)) {
       throw new RangeError('MaxSizePixelHeight cannot be NaN');
     }
-    this[DataViewSymbol][12] = attributeValue;
+
+    this[DataViewSymbol][13] = attributeValue;
   }
 
   get MinSizePixelWidth(): number {
-    return this[DataViewSymbol][13];
+    return this[DataViewSymbol][14];
   }
 
   set MinSizePixelWidth(attributeValue: number) {
     if (isNaN(attributeValue)) {
       throw new RangeError('MinSizePixelWidth cannot be NaN');
     }
-    this[DataViewSymbol][13] = attributeValue;
+
+    this[DataViewSymbol][14] = attributeValue;
   }
 
   get MinSizePixelHeight(): number {
-    return this[DataViewSymbol][14];
+    return this[DataViewSymbol][15];
   }
 
   set MinSizePixelHeight(attributeValue: number) {
     if (isNaN(attributeValue)) {
       throw new RangeError('MinSizePixelHeight cannot be NaN');
     }
-    this[DataViewSymbol][14] = attributeValue;
+
+    this[DataViewSymbol][15] = attributeValue;
   }
 
   get PositionRelativeX(): number {
-    return this[DataViewSymbol][15];
+    return this[DataViewSymbol][16];
   }
 
   set PositionRelativeX(attributeValue: number) {
     if (isNaN(attributeValue)) {
       throw new RangeError('PositionRelativeX cannot be NaN');
     }
-    this[DataViewSymbol][15] = attributeValue;
+
+    this[DataViewSymbol][16] = attributeValue;
   }
 
   get PositionRelativeY(): number {
-    return this[DataViewSymbol][16];
+    return this[DataViewSymbol][17];
   }
 
   set PositionRelativeY(attributeValue: number) {
     if (isNaN(attributeValue)) {
       throw new RangeError('PositionRelativeY cannot be NaN');
     }
-    this[DataViewSymbol][16] = attributeValue;
+
+    this[DataViewSymbol][17] = attributeValue;
   }
 
   get Sides(): number {
-    return this[DataViewSymbol][17];
+    return this[DataViewSymbol][18];
   }
 
   set Sides(attributeValue: number) {
     if (isNaN(attributeValue)) {
       throw new RangeError('Sides cannot be NaN');
     }
-    this[DataViewSymbol][17] = attributeValue;
+
+    this[DataViewSymbol][18] = attributeValue;
   }
 
   get ShapeTextureU(): number {
-    return this[DataViewSymbol][18];
+    return this[DataViewSymbol][19];
   }
 
   set ShapeTextureU(attributeValue: number) {
     if (isNaN(attributeValue)) {
       throw new RangeError('ShapeTextureU cannot be NaN');
     }
-    this[DataViewSymbol][18] = attributeValue;
+
+    this[DataViewSymbol][19] = attributeValue;
   }
 
   get ShapeTextureV(): number {
-    return this[DataViewSymbol][19];
+    return this[DataViewSymbol][20];
   }
 
   set ShapeTextureV(attributeValue: number) {
     if (isNaN(attributeValue)) {
       throw new RangeError('ShapeTextureV cannot be NaN');
     }
-    this[DataViewSymbol][19] = attributeValue;
+
+    this[DataViewSymbol][20] = attributeValue;
   }
 
   get ShapeTextureWidth(): number {
-    return this[DataViewSymbol][20];
+    return this[DataViewSymbol][21];
   }
 
   set ShapeTextureWidth(attributeValue: number) {
     if (isNaN(attributeValue)) {
       throw new RangeError('ShapeTextureWidth cannot be NaN');
     }
-    this[DataViewSymbol][20] = attributeValue;
+
+    this[DataViewSymbol][21] = attributeValue;
   }
 
   get ShapeTextureHeight(): number {
-    return this[DataViewSymbol][21];
+    return this[DataViewSymbol][22];
   }
 
   set ShapeTextureHeight(attributeValue: number) {
     if (isNaN(attributeValue)) {
       throw new RangeError('ShapeTextureHeight cannot be NaN');
     }
-    this[DataViewSymbol][21] = attributeValue;
+
+    this[DataViewSymbol][22] = attributeValue;
   }
 
   get BorderRadiusWorld(): number {
-    return this[DataViewSymbol][22];
+    return this[DataViewSymbol][23];
   }
 
   set BorderRadiusWorld(attributeValue: number) {
     if (isNaN(attributeValue)) {
       throw new RangeError('BorderRadiusWorld cannot be NaN');
     }
-    this[DataViewSymbol][22] = attributeValue;
+
+    this[DataViewSymbol][23] = attributeValue;
   }
 
   get BorderRadiusPixel(): number {
-    return this[DataViewSymbol][23];
+    return this[DataViewSymbol][24];
   }
 
   set BorderRadiusPixel(attributeValue: number) {
     if (isNaN(attributeValue)) {
       throw new RangeError('BorderRadiusPixel cannot be NaN');
     }
-    this[DataViewSymbol][23] = attributeValue;
+
+    this[DataViewSymbol][24] = attributeValue;
   }
 
   get BorderPlacement(): number {
-    return this[DataViewSymbol][24];
+    return this[DataViewSymbol][25];
   }
 
   set BorderPlacement(attributeValue: number) {
     if (isNaN(attributeValue)) {
       throw new RangeError('BorderPlacement cannot be NaN');
     }
-    this[DataViewSymbol][24] = attributeValue;
+
+    this[DataViewSymbol][25] = attributeValue;
   }
 
   get BorderColorR(): number {
-    return this[DataViewSymbol][25];
+    return this[DataViewSymbol][26];
   }
 
   set BorderColorR(attributeValue: number) {
     if (isNaN(attributeValue)) {
       throw new RangeError('BorderColorR cannot be NaN');
     }
-    this[DataViewSymbol][25] = attributeValue;
+
+    this[DataViewSymbol][26] = attributeValue;
   }
 
   get BorderColorG(): number {
-    return this[DataViewSymbol][26];
+    return this[DataViewSymbol][27];
   }
 
   set BorderColorG(attributeValue: number) {
     if (isNaN(attributeValue)) {
       throw new RangeError('BorderColorG cannot be NaN');
     }
-    this[DataViewSymbol][26] = attributeValue;
+
+    this[DataViewSymbol][27] = attributeValue;
   }
 
   get BorderColorB(): number {
-    return this[DataViewSymbol][27];
+    return this[DataViewSymbol][28];
   }
 
   set BorderColorB(attributeValue: number) {
     if (isNaN(attributeValue)) {
       throw new RangeError('BorderColorB cannot be NaN');
     }
-    this[DataViewSymbol][27] = attributeValue;
+
+    this[DataViewSymbol][28] = attributeValue;
   }
 
   get BorderColorOpacity(): number {
-    return this[DataViewSymbol][28];
+    return this[DataViewSymbol][29];
   }
 
   set BorderColorOpacity(attributeValue: number) {
     if (isNaN(attributeValue)) {
       throw new RangeError('BorderColorOpacity cannot be NaN');
     }
-    this[DataViewSymbol][28] = attributeValue;
+
+    this[DataViewSymbol][29] = attributeValue;
   }
 
   get FillBlend(): number {
-    return this[DataViewSymbol][29];
+    return this[DataViewSymbol][30];
   }
 
   set FillBlend(attributeValue: number) {
     if (isNaN(attributeValue)) {
       throw new RangeError('FillBlend cannot be NaN');
     }
-    this[DataViewSymbol][29] = attributeValue;
+
+    this[DataViewSymbol][30] = attributeValue;
   }
 
   get FillColorR(): number {
-    return this[DataViewSymbol][30];
+    return this[DataViewSymbol][31];
   }
 
   set FillColorR(attributeValue: number) {
     if (isNaN(attributeValue)) {
       throw new RangeError('FillColorR cannot be NaN');
     }
-    this[DataViewSymbol][30] = attributeValue;
+
+    this[DataViewSymbol][31] = attributeValue;
   }
 
   get FillColorG(): number {
-    return this[DataViewSymbol][31];
+    return this[DataViewSymbol][32];
   }
 
   set FillColorG(attributeValue: number) {
     if (isNaN(attributeValue)) {
       throw new RangeError('FillColorG cannot be NaN');
     }
-    this[DataViewSymbol][31] = attributeValue;
+
+    this[DataViewSymbol][32] = attributeValue;
   }
 
   get FillColorB(): number {
-    return this[DataViewSymbol][32];
+    return this[DataViewSymbol][33];
   }
 
   set FillColorB(attributeValue: number) {
     if (isNaN(attributeValue)) {
       throw new RangeError('FillColorB cannot be NaN');
     }
-    this[DataViewSymbol][32] = attributeValue;
+
+    this[DataViewSymbol][33] = attributeValue;
   }
 
   get FillColorOpacity(): number {
-    return this[DataViewSymbol][33];
+    return this[DataViewSymbol][34];
   }
 
   set FillColorOpacity(attributeValue: number) {
     if (isNaN(attributeValue)) {
       throw new RangeError('FillColorOpacity cannot be NaN');
     }
-    this[DataViewSymbol][33] = attributeValue;
+
+    this[DataViewSymbol][34] = attributeValue;
   }
 
   get FillTextureU(): number {
-    return this[DataViewSymbol][34];
+    return this[DataViewSymbol][35];
   }
 
   set FillTextureU(attributeValue: number) {
     if (isNaN(attributeValue)) {
       throw new RangeError('FillTextureU cannot be NaN');
     }
-    this[DataViewSymbol][34] = attributeValue;
+
+    this[DataViewSymbol][35] = attributeValue;
   }
 
   get FillTextureV(): number {
-    return this[DataViewSymbol][35];
+    return this[DataViewSymbol][36];
   }
 
   set FillTextureV(attributeValue: number) {
     if (isNaN(attributeValue)) {
       throw new RangeError('FillTextureV cannot be NaN');
     }
-    this[DataViewSymbol][35] = attributeValue;
+
+    this[DataViewSymbol][36] = attributeValue;
   }
 
   get FillTextureWidth(): number {
-    return this[DataViewSymbol][36];
+    return this[DataViewSymbol][37];
   }
 
   set FillTextureWidth(attributeValue: number) {
     if (isNaN(attributeValue)) {
       throw new RangeError('FillTextureWidth cannot be NaN');
     }
-    this[DataViewSymbol][36] = attributeValue;
+
+    this[DataViewSymbol][37] = attributeValue;
   }
 
   get FillTextureHeight(): number {
-    return this[DataViewSymbol][37];
+    return this[DataViewSymbol][38];
   }
 
   set FillTextureHeight(attributeValue: number) {
     if (isNaN(attributeValue)) {
       throw new RangeError('FillTextureHeight cannot be NaN');
     }
-    this[DataViewSymbol][37] = attributeValue;
+
+    this[DataViewSymbol][38] = attributeValue;
   }
 
   set PositionWorld(value: (number[] | {x?: number; y?: number;})) {

--- a/src/lib/generated/sprite-view.d.ts
+++ b/src/lib/generated/sprite-view.d.ts
@@ -24,6 +24,7 @@ export interface SpriteView {
   PositionWorldY: number;
   SizeWorldWidth: number;
   SizeWorldHeight: number;
+  OrderZ: number;
   GeometricZoomX: number;
   GeometricZoomY: number;
   PositionPixelX: number;

--- a/src/lib/scene-internal.ts
+++ b/src/lib/scene-internal.ts
@@ -100,6 +100,13 @@ export class SceneInternal implements Renderer {
   });
 
   /**
+   * Granularity of OrderZ values. Higher means more granular control over
+   * user-specified OrderZ, but reduces precision remaining for differentiating
+   * stacked sprites with the same OrderZ.
+   */
+  orderZGranularity: number;
+
+  /**
    * Collection of Sprites that have been created and have swatches
    * assigned.
    */
@@ -453,6 +460,7 @@ export class SceneInternal implements Renderer {
 
     this.container = settings.container;
     this.defaultTransitionTimeMs = settings.defaultTransitionTimeMs;
+    this.orderZGranularity = settings.orderZGranularity;
 
     // Look for either the REGL module or createREGL global since both are
     // supported. The latter is for hot-loading the standalone Regl JS file.

--- a/src/lib/shaders/scene-fragment-shader.ts
+++ b/src/lib/shaders/scene-fragment-shader.ts
@@ -338,10 +338,17 @@ void main () {
   float targetDistance = getDist(targetSides, varyingTargetShapeTexture);
   float signedDistance = mix(previousDistance, targetDistance, varyingT);
 
-  gl_FragColor =
+  vec4 color =
     signedDistance < varyingBorderThresholds.x ? vec4(0.) :
     signedDistance < varyingBorderThresholds.y ? varyingBorderColor :
     varyingFillColor;
+
+  if (color.a < .01) {
+    discard;
+    return;
+  }
+
+  gl_FragColor = color;
 }
 `;
 }

--- a/src/lib/shaders/scene-vertex-shader.ts
+++ b/src/lib/shaders/scene-vertex-shader.ts
@@ -67,11 +67,12 @@ precision lowp float;
 uniform float ts;
 
 /**
- * Incremental clip-space Z for stacking sprites based on their instanceIndex.
+ * Total number of sprite instances being rendered this pass. Used to compute
+ * clip-space Z for stacking sprites based on their instanceIndex.
  * This ensures that partial-opacity pixels of stacked sprites will be
  * alpha-blended. Without this, occluded sprites' pixels may not blend.
  */
-uniform float instanceZ;
+uniform float instanceCount;
 
 /**
  * View and projection matrices for converting from world space to clip space.
@@ -331,9 +332,8 @@ void main () {
   vec2 clipVertexPosition =
     (projectionMatrix * vec3(viewVertexPosition, 1.)).xy;
 
-  // Align Z axis clip-space coordinate (perpendicular to screen) with instance
-  // index for blending stacked sprites.
-  gl_Position = vec4(clipVertexPosition, -instanceIndex * instanceZ, 1.);
+  float clipZ = -instanceIndex / instanceCount;
+  gl_Position = vec4(clipVertexPosition, clipZ, 1.);
 }
 `;
 }

--- a/src/lib/sprite-attributes.ts
+++ b/src/lib/sprite-attributes.ts
@@ -59,6 +59,16 @@ export interface SpriteAttribute {
    * this property is absent, then the attribute is presumed to be a float.
    */
   readonly components?: readonly string[];
+
+  /**
+   * Minimum allowable value of this attribute. Enforced by runtime checks.
+   */
+  readonly minValue?: number;
+
+  /**
+   * Maximum allowable value of this attribute. Enforced by runtime checks.
+   */
+  readonly maxValue?: number;
 }
 
 /**
@@ -97,6 +107,29 @@ export const SPRITE_ATTRIBUTES: readonly SpriteAttribute[] = [
     isInterpolable: true,
     isBroadcastable: true,
     components: ['Width', 'Height'],
+  },
+
+  /**
+   * By default, when rendering, sprites are stacked such that later allocated
+   * sprites appear on top of earlier sprites. This guarantees that when sprites
+   * overlap and have partially transparent pixels, the pixel values blend
+   * appropriately.
+   *
+   * However, sometimes it's beneficial to override the Z ordering, even if that
+   * could cause blending issues. For example, when a user hovers over a point,
+   * it could make sense to raise that sprite to the top.
+   *
+   * The OrderZ attribute allows the API user to override the default stacking.
+   * If specified, this value should be in the range 0-1. Any sprite with a
+   * specified non-zero OrderZ will be rendered on top of any sprites with
+   * unspecified OrderZ. When two sprites both have OrderZs set, the one with
+   * the higher value will be on top.
+   */
+  {
+    attributeName: 'OrderZ',
+    isInterpolable: true,
+    minValue: 0,
+    maxValue: 1,
   },
 
   /**

--- a/test/attribute-mapper.test.ts
+++ b/test/attribute-mapper.test.ts
@@ -106,6 +106,31 @@ describe('AttributeMapper', () => {
     expect(attributeComponentIndices['PositionZDelta']).toBe(6);
   });
 
+  it('should set up component-to-attribute map', () => {
+    const attributes = [
+      {
+        attributeName: 'TransitionTimeMs',
+      },
+      {
+        attributeName: 'Position',
+        isInterpolable: true,
+        components: ['X', 'Y', 'Z'],
+      },
+    ];
+
+    const {componentToAttributeMap} = new AttributeMapper({
+      maxTextureSize: DEFAULT_MAX_TEXTURE_SIZE,
+      attributes,
+    });
+
+    expect(Object.keys(componentToAttributeMap).length).toBe(4);
+
+    expect(componentToAttributeMap['TransitionTimeMs']).toBe(attributes[0]);
+    expect(componentToAttributeMap['PositionX']).toBe(attributes[1]);
+    expect(componentToAttributeMap['PositionY']).toBe(attributes[1]);
+    expect(componentToAttributeMap['PositionZ']).toBe(attributes[1]);
+  });
+
   describe('generateTexelReaderGLSL', () => {
     it('should generate data texture reader GLSL code', () => {
       const attributes = [

--- a/util/generate-code.ts
+++ b/util/generate-code.ts
@@ -155,6 +155,9 @@ export class SpriteViewImpl implements SpriteView {
       continue;
     }
 
+    const attribute =
+        attributeMapper.componentToAttributeMap[attributeComponentName];
+
     output.push(`
   get ${attributeComponentName}(): number {
     return this[DataViewSymbol][${i}];
@@ -163,7 +166,25 @@ export class SpriteViewImpl implements SpriteView {
   set ${attributeComponentName}(attributeValue: number) {
     if (isNaN(attributeValue)) {
       throw new RangeError('${attributeComponentName} cannot be NaN');
+    }`);
+
+    if (attribute.minValue !== undefined) {
+      output.push(`
+    if (attributeValue < ${attribute.minValue}) {
+      throw new RangeError('${attributeComponentName} cannot be less than ${
+          attribute.minValue}');
+    }`);
     }
+
+    if (attribute.maxValue !== undefined) {
+      output.push(`
+    if (attributeValue > ${attribute.maxValue}) {
+      throw new RangeError('${attributeComponentName} cannot be greater than ${
+          attribute.maxValue}');
+    }`);
+    }
+
+    output.push(`
     this[DataViewSymbol][${i}] = attributeValue;
   }`);
   }


### PR DESCRIPTION
Introduces a new sprite attribute `OrderZ` which can be used to specify the Z ordering of sprites. If specified, it must be a value from `0` to `1` inclusive. The default value if not specified is `0`.

Examples:

```ts
// Native Sprite.
const sprite = scene.createSprite();
sprite.enter((s: SpriteView) => {
  s.OrderZ = 0.2;
});

// Selection.
const selection = scene.createSelection<Datum>();
selection.onBind((s: SpriteView, d: Datum) => {
  s.OrderZ = d.someProperty;
});
selection.bind(dataArray);
```

When two sprites have the same `OrderZ` value, the one which was created later will be rendered on top of the earlier one.

CAVEAT: Partially transparent pixels will not blend correctly if `OrderZ` values cause an earlier sprite to render on top of a later sprite. Fully transparent pixels will work as intended however, as those are explicitly discarded. In practice this means that when using OrderZ to place sprites above other sprites, it's prudent to make the top sprites opaque.

Satisfies #34 and probably obviates #15.