### PR TITLE
`devicePixelRatio`: fix rendering, `resize()` logic, expose setting and add tests

### DIFF
--- a/src/demo/debugging-demo.ts
+++ b/src/demo/debugging-demo.ts
@@ -255,8 +255,9 @@ function main() {
   gui.add(settings, 'inclusive');
   gui.add(settings, 'brush');
   gui.add(settings, 'clearBeforeUpdate');
-  gui.add(settings, 'devicePixelRatio', 0.5, 3, .5)
-      .onChange(() => scene.resize());
+  gui.add(settings, 'devicePixelRatio', 0.5, 3, .5).onChange(() => {
+    scene.resize();
+  });
   update();
   container.appendChild(gui.domElement);
 

--- a/src/demo/debugging-demo.ts
+++ b/src/demo/debugging-demo.ts
@@ -60,35 +60,6 @@ const TEXT_BORDER = d3.color('black') as d3.RGBColor;
 const TEXT_FILL = d3.color('white') as d3.RGBColor;
 
 function main() {
-  // Locate the container element.
-  const container = d3.select('body').node() as HTMLElement;
-
-  // Create a Scene to be rendered in a fresh canvas fitted to container.
-  const scene = new Scene({
-    container,
-    defaultTransitionTimeMs: 0,
-    desiredSpriteCapacity: MAX_CAPACITY,
-  });
-
-  const {workScheduler} = scene[SceneInternalSymbol];
-
-  // Add frame rate stats panel.
-  const stats = new Stats();
-  stats.showPanel(0);
-  Object.assign(stats.dom.style, {
-    bottom: 0,
-    left: null,
-    position: 'absolute',
-    right: 0,
-    top: null,
-  });
-  container.appendChild(stats.dom);
-  function loop() {
-    stats.update();
-    requestAnimationFrame(loop);
-  }
-  loop();
-
   // Configuration option for dat.GUI settings.
   const settings = {
     total: 0,
@@ -115,7 +86,38 @@ function main() {
     inclusive: true,
     brush: false,
     clearBeforeUpdate: false,
+    devicePixelRatio: window.devicePixelRatio || 1,
   };
+
+  // Locate the container element.
+  const container = d3.select('body').node() as HTMLElement;
+
+  // Create a Scene to be rendered in a fresh canvas fitted to container.
+  const scene = new Scene({
+    container,
+    defaultTransitionTimeMs: 0,
+    desiredSpriteCapacity: MAX_CAPACITY,
+    devicePixelRatio: () => settings.devicePixelRatio,
+  });
+
+  const {workScheduler} = scene[SceneInternalSymbol];
+
+  // Add frame rate stats panel.
+  const stats = new Stats();
+  stats.showPanel(0);
+  Object.assign(stats.dom.style, {
+    bottom: 0,
+    left: null,
+    position: 'absolute',
+    right: 0,
+    top: null,
+  });
+  container.appendChild(stats.dom);
+  function loop() {
+    stats.update();
+    requestAnimationFrame(loop);
+  }
+  loop();
 
   const colors = d3.schemeCategory10;
   const borderColor = d3.color('rgba(255,0,0,0.5)') as d3.RGBColor;
@@ -253,6 +255,8 @@ function main() {
   gui.add(settings, 'inclusive');
   gui.add(settings, 'brush');
   gui.add(settings, 'clearBeforeUpdate');
+  gui.add(settings, 'devicePixelRatio', 0.5, 3, .5)
+      .onChange(() => scene.resize());
   update();
   container.appendChild(gui.domElement);
 

--- a/src/lib/default-scene-settings.ts
+++ b/src/lib/default-scene-settings.ts
@@ -36,6 +36,7 @@ export const DEFAULT_SCENE_SETTINGS: SceneSettings = Object.freeze({
   container: document.body,
   defaultTransitionTimeMs: 250,
   desiredSpriteCapacity: 1e6,
+  devicePixelRatio: undefined,
   glyphs: DEFAULT_GLYPHS,
   glyphMapper: DEFAULT_GLYPH_MAPPER_SETTINGS,
   orderZGranularity: 10,
@@ -56,6 +57,9 @@ export const DEFAULT_SCENE_SETTINGS: SceneSettings = Object.freeze({
  *     headroom when setting this value; failure to do so can cause your sprites
  *     to not render in the Scene even though the .bind(), etc. callbacks may
  *     fire for the datum and its associated SpriteView.
+ * @param {number|(() => number)} devicePixelRatio Optional static number or a
+ *     function to provide devicePixelRatio setting instead of accessing the
+ *     global value each time.
  * @param {string} glyphs Characters to support in glyph mapper.
  * @param {GlyphMapperSettings} glyphMapper Settings for the glyph mapper.
  * @param {number} orderZGranularity Granularity of OrderZ values. Higher means
@@ -67,6 +71,7 @@ export interface SceneSettings {
   container: HTMLElement;
   defaultTransitionTimeMs: number;
   desiredSpriteCapacity: number;
+  devicePixelRatio?: number|(() => number);
   glyphs: string;
   glyphMapper: GlyphMapperSettings;
   orderZGranularity: number;

--- a/src/lib/scene-internal.ts
+++ b/src/lib/scene-internal.ts
@@ -57,6 +57,13 @@ import {WorkTaskId} from './work-task';
  */
 const STEPS_BETWEEN_REMAINING_TIME_CHECKS = 500;
 
+/**
+ * WebGL vertex shaders output coordinates in clip space, which is a 3D volume
+ * where each component is clipped to the range (-1,1). The distance from
+ * edge-to-edge is therefore 2.
+ */
+const CLIP_SPACE_RANGE = 2;
+
 export class SceneInternal implements Renderer {
   /**
    * Container element to pass to Regl for rendering. Regl will place a canvas
@@ -874,7 +881,7 @@ export class SceneInternal implements Renderer {
       throw new InternalError('initView must set lastDevicePixelRatio');
     }
 
-    const scaleFactor = 2 * this.lastDevicePixelRatio;
+    const scaleFactor = CLIP_SPACE_RANGE * this.lastDevicePixelRatio;
     return [
       // Column 0.
       this.scale.x * scaleFactor,
@@ -882,7 +889,7 @@ export class SceneInternal implements Renderer {
       0,
       // Column 1.
       0,
-      this.scale.y * -scaleFactor,
+      this.scale.y * -scaleFactor,  // Invert Y.
       0,
       // Column 2.
       this.offset.x * scaleFactor,
@@ -900,7 +907,7 @@ export class SceneInternal implements Renderer {
       throw new InternalError('initView must set lastDevicePixelRatio');
     }
 
-    const scaleFactor = 2 * this.lastDevicePixelRatio;
+    const scaleFactor = CLIP_SPACE_RANGE * this.lastDevicePixelRatio;
     const scaleX = this.scale.x * scaleFactor;
     const scaleY = this.scale.y * scaleFactor;
     return [scaleX, scaleY, 1 / scaleX, 1 / scaleY];

--- a/src/lib/scene-internal.ts
+++ b/src/lib/scene-internal.ts
@@ -839,18 +839,19 @@ export class SceneInternal implements Renderer {
    * View matrix converts world units into view (pixel) coordinates.
    */
   getViewMatrix() {
+    const scaleFactor = 2 * this.devicePixelRatio;
     return [
       // Column 0.
-      4 * this.scale.x,
+      this.scale.x * scaleFactor,
       0,
       0,
       // Column 1.
       0,
-      -4 * this.scale.y,
+      this.scale.y * -scaleFactor,
       0,
       // Column 2.
-      4 * this.offset.x,
-      4 * this.offset.y,
+      this.offset.x * scaleFactor,
+      this.offset.y * scaleFactor,
       1,
     ];
   }
@@ -860,12 +861,10 @@ export class SceneInternal implements Renderer {
    * vertex shader.
    */
   getViewMatrixScale() {
-    return [
-      4 * this.scale.x,
-      4 * this.scale.y,
-      .25 / this.scale.x,
-      .25 / this.scale.y,
-    ];
+    const scaleFactor = 2 * this.devicePixelRatio;
+    const scaleX = this.scale.x * scaleFactor;
+    const scaleY = this.scale.y * scaleFactor;
+    return [scaleX, scaleY, 1 / scaleX, 1 / scaleY];
   }
 
   /**

--- a/test/scene-integration.test.ts
+++ b/test/scene-integration.test.ts
@@ -18,6 +18,7 @@
  * @fileoverview Tests for the Scene.
  */
 
+import {SpriteView} from '../src/lib/generated/sprite-view';
 import {Scene} from '../src/lib/scene';
 import {SceneInternalSymbol} from '../src/lib/symbols';
 import {TimingFunctionsShim} from '../src/lib/timing-functions-shim';
@@ -122,6 +123,41 @@ function compareColorArrays(
   return matches / (expected.length / 4);
 }
 
+/**
+ * Set a SpriteView's attributes to make the sprite a magenta filled square with
+ * green border.
+ */
+function makeGreenMagentaSquare(s: SpriteView) {
+  // Position of the sprite should be centered at world origin.
+  s.PositionWorldX = 0;
+  s.PositionWorldY = 0;
+
+  // Sprite size should fill the canvas.
+  s.SizeWorldWidth = 1;
+  s.SizeWorldHeight = 1;
+
+  // Shape should be a square.
+  s.Sides = 2;
+
+  // Border should be 1/4 of a world unit, half the radius of the
+  // of the shape.
+  s.BorderPlacement = 0;
+  s.BorderRadiusWorld = .25;
+  s.BorderRadiusPixel = 0;
+
+  // Border is opaque green.
+  s.BorderColorR = 0;
+  s.BorderColorG = 255;
+  s.BorderColorB = 0;
+  s.BorderColorOpacity = 1;
+
+  // Interior fill is opaque magenta.
+  s.FillColorR = 255;
+  s.FillColorG = 0;
+  s.FillColorB = 255;
+  s.FillColorOpacity = 1;
+}
+
 describe('Scene', () => {
   describe('initialization', () => {
     const section = createSection('Scene initialization');
@@ -149,40 +185,7 @@ describe('Scene', () => {
 
       // Create a Sprite and render it.
       const sprite = scene.createSprite();
-
-      // Give the Sprite an enter() callback to invoke.
-      sprite.enter((s) => {
-        // Position of the sprite should be centered at world origin.
-        s.PositionWorldX = 0;
-        s.PositionWorldY = 0;
-
-        // Sprite size should fill the canvas.
-        s.SizeWorldWidth = 1;
-        s.SizeWorldHeight = 1;
-
-        // Shape should be a square.
-        s.Sides = 2;
-
-        // Border should be 1/4 of a world unit, half the radius of the
-        // of the shape.
-        s.BorderPlacement = 0;
-        s.BorderRadiusWorld = .25;
-        s.BorderRadiusPixel = 0;
-
-        // Border is opaque green.
-        s.BorderColorR = 0;
-        s.BorderColorG = 255;
-        s.BorderColorB = 0;
-        s.BorderColorOpacity = 1;
-
-        // Interior fill is opaque magenta.
-        s.FillColorR = 255;
-        s.FillColorG = 0;
-        s.FillColorB = 255;
-        s.FillColorOpacity = 1;
-      });
-
-      // Three frames to run callbacks, flash data texture and draw.
+      sprite.enter(makeGreenMagentaSquare);
       timingFunctionsShim.runAnimationFrameCallbacks(3);
 
       // Now, if we inspect the canvas, its pixels should show that the
@@ -274,39 +277,7 @@ describe('Scene', () => {
 
       // Create a Sprite and render it.
       const sprite = scene.createSprite();
-
-      // Give the Sprite an enter() callback to invoke.
-      sprite.enter((s) => {
-        // Position of the sprite should be centered at world origin.
-        s.PositionWorldX = 0;
-        s.PositionWorldY = 0;
-
-        // Sprite size should fill the canvas.
-        s.SizeWorldWidth = 1;
-        s.SizeWorldHeight = 1;
-
-        // Shape should be a square.
-        s.Sides = 2;
-
-        // Border should be 1/4 of a world unit, half the radius of the
-        // of the shape.
-        s.BorderPlacement = 0;
-        s.BorderRadiusWorld = .25;
-        s.BorderRadiusPixel = 0;
-
-        // Border is opaque green.
-        s.BorderColorR = 0;
-        s.BorderColorG = 255;
-        s.BorderColorB = 0;
-        s.BorderColorOpacity = 1;
-
-        // Interior fill is opaque magenta.
-        s.FillColorR = 255;
-        s.FillColorG = 0;
-        s.FillColorB = 255;
-        s.FillColorOpacity = 1;
-      });
-
+      sprite.enter(makeGreenMagentaSquare);
       timingFunctionsShim.runAnimationFrameCallbacks(4);
 
       // Now, if we inspect the canvas, its pixels should show that the sprite
@@ -388,39 +359,7 @@ describe('Scene', () => {
 
       // Create a Sprite and render it.
       const sprite = scene.createSprite();
-
-      // Give the Sprite an enter() callback to invoke.
-      sprite.enter((s) => {
-        // Position of the sprite should be centered at world origin.
-        s.PositionWorldX = 0;
-        s.PositionWorldY = 0;
-
-        // Sprite size should fill the canvas.
-        s.SizeWorldWidth = 1;
-        s.SizeWorldHeight = 1;
-
-        // Shape should be a square.
-        s.Sides = 2;
-
-        // Border should be 1/4 of a world unit, half the radius of the
-        // of the shape.
-        s.BorderPlacement = 0;
-        s.BorderRadiusWorld = .25;
-        s.BorderRadiusPixel = 0;
-
-        // Border is opaque green.
-        s.BorderColorR = 0;
-        s.BorderColorG = 255;
-        s.BorderColorB = 0;
-        s.BorderColorOpacity = 1;
-
-        // Interior fill is opaque magenta.
-        s.FillColorR = 255;
-        s.FillColorG = 0;
-        s.FillColorB = 255;
-        s.FillColorOpacity = 1;
-      });
-
+      sprite.enter(makeGreenMagentaSquare);
       timingFunctionsShim.runAnimationFrameCallbacks(4);
 
       // Now change the devicePixelRatio and resize(). This simulates moving the
@@ -492,448 +431,88 @@ describe('Scene', () => {
     const section = createSection('Scene::devicePixelRatio');
     const sectionContent = section.querySelector('.content')!;
 
-    it('should render normally at devicePixelRatio=0.5', async () => {
-      const container = document.createElement('div');
-      container.style.width = '100px';
-      container.style.height = '100px';
-      sectionContent.appendChild(container);
+    const devicePixelRatioParameters = [0.5, 1, 1.5, 2, 2.5, 3];
 
-      const timingFunctionsShim = new TimingFunctionsShim();
-      timingFunctionsShim.totalElapsedTimeMs = 1234500000;
+    for (const dpr of devicePixelRatioParameters) {
+      it(`should render at devicePixelRatio=${dpr}`, async () => {
+        const container = document.createElement('div');
+        container.style.width = '100px';
+        container.style.height = '100px';
+        sectionContent.appendChild(container);
 
-      const scene = new Scene({
-        container,
-        defaultTransitionTimeMs: 0,
-        desiredSpriteCapacity: 100,
-        devicePixelRatio: 0.5,
-        timingFunctions: timingFunctionsShim,
+        const timingFunctionsShim = new TimingFunctionsShim();
+        timingFunctionsShim.totalElapsedTimeMs = 1234500000;
+
+        const scene = new Scene({
+          container,
+          defaultTransitionTimeMs: 0,
+          desiredSpriteCapacity: 100,
+          devicePixelRatio: dpr,
+          timingFunctions: timingFunctionsShim,
+        });
+
+        // Create a Sprite and render it.
+        const sprite = scene.createSprite();
+        sprite.enter(makeGreenMagentaSquare);
+        timingFunctionsShim.runAnimationFrameCallbacks(4);
+
+        // Now, if we inspect the canvas, its pixels should show that the sprite
+        // has been rendered. Start my making a copy of the canvas and for
+        // inspection.
+        const {canvas} = scene;
+        const [copy, ctx, copyContainer] = copyCanvasAndContainer(canvas);
+        sectionContent.appendChild(copyContainer);
+
+        // Grab a snapshot of the Scene's rendered pixels and draw them to
+        // the canvas copy.
+        const blob = await scene[SceneInternalSymbol].snapshot();
+        const img = await blobToImage(blob);
+        ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
+
+        // For integration testing, we'll sample areas of the output that are
+        // 10% the width and height of the canvas size. This patch is a
+        // middle-ground between testing the whole image for pixel-perfect
+        // rendering and testing a single pixel.
+        const sampleWidth = Math.ceil(copy.width * .1);
+        const sampleHeight = Math.ceil(copy.width * .1);
+        const pixelCount = sampleWidth * sampleHeight;
+
+        // Generate patches of solid green and magenta to compare to the
+        // rendered pixels for correctness.
+        const greenPatch = filledColorArray(pixelCount, [0, 255, 0, 255]);
+        const magentaPatch = filledColorArray(pixelCount, [255, 0, 255, 255]);
+
+        // Take a sample of the top left corner and compare it to the expected
+        // solid green patch.
+        const topLeftSample = ctx.getImageData(
+            0,
+            0,
+            sampleWidth,
+            sampleHeight,
+        );
+        expect(compareColorArrays(topLeftSample.data, greenPatch)).toEqual(1);
+
+        // Take a sample of the bottom right corner and compare it to the
+        // expected solid green patch.
+        const bottomRightSample = ctx.getImageData(
+            Math.floor(copy.width - sampleWidth),
+            Math.floor(copy.height - sampleHeight),
+            sampleWidth,
+            sampleHeight,
+        );
+        expect(compareColorArrays(bottomRightSample.data, greenPatch))
+            .toEqual(1);
+
+        // Lastly, sample a chunk of the middle of the image and compare it to
+        // the solid magenta patch.
+        const centerSample = ctx.getImageData(
+            Math.floor(copy.width * .5 - sampleWidth * .5),
+            Math.floor(copy.height * .5 - sampleHeight * .5),
+            sampleWidth,
+            sampleHeight,
+        );
+        expect(compareColorArrays(centerSample.data, magentaPatch)).toEqual(1);
       });
-
-      // Create a Sprite and render it.
-      const sprite = scene.createSprite();
-
-      // Give the Sprite an enter() callback to invoke.
-      sprite.enter((s) => {
-        // Position of the sprite should be centered at world origin.
-        s.PositionWorldX = 0;
-        s.PositionWorldY = 0;
-
-        // Sprite size should fill the canvas.
-        s.SizeWorldWidth = 1;
-        s.SizeWorldHeight = 1;
-
-        // Shape should be a square.
-        s.Sides = 2;
-
-        // Border should be 1/4 of a world unit, half the radius of the
-        // of the shape.
-        s.BorderPlacement = 0;
-        s.BorderRadiusWorld = .25;
-        s.BorderRadiusPixel = 0;
-
-        // Border is opaque green.
-        s.BorderColorR = 0;
-        s.BorderColorG = 255;
-        s.BorderColorB = 0;
-        s.BorderColorOpacity = 1;
-
-        // Interior fill is opaque magenta.
-        s.FillColorR = 255;
-        s.FillColorG = 0;
-        s.FillColorB = 255;
-        s.FillColorOpacity = 1;
-      });
-
-      timingFunctionsShim.runAnimationFrameCallbacks(4);
-
-      // Now, if we inspect the canvas, its pixels should show that the sprite
-      // has been rendered. Start my making a copy of the canvas and for
-      // inspection.
-      const {canvas} = scene;
-      const [copy, ctx, copyContainer] = copyCanvasAndContainer(canvas);
-      sectionContent.appendChild(copyContainer);
-
-      // Grab a snapshot of the Scene's rendered pixels and draw them to
-      // the canvas copy.
-      const blob = await scene[SceneInternalSymbol].snapshot();
-      const img = await blobToImage(blob);
-      ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
-
-      // For integration testing, we'll sample areas of the output that are 10%
-      // the width and height of the canvas size. This patch is a middle-ground
-      // between testing the whole image for pixel-perfect rendering and testing
-      // a single pixel.
-      const sampleWidth = Math.ceil(copy.width * .1);
-      const sampleHeight = Math.ceil(copy.width * .1);
-      const pixelCount = sampleWidth * sampleHeight;
-
-      // Generate patches of solid green and magenta to compare to the rendered
-      // pixels for correctness.
-      const greenPatch = filledColorArray(pixelCount, [0, 255, 0, 255]);
-      const magentaPatch = filledColorArray(pixelCount, [255, 0, 255, 255]);
-
-      // Take a sample of the top left corner and compare it to the expected
-      // solid green patch.
-      const topLeftSample = ctx.getImageData(
-          0,
-          0,
-          sampleWidth,
-          sampleHeight,
-      );
-      expect(compareColorArrays(topLeftSample.data, greenPatch)).toEqual(1);
-
-      // Take a sample of the bottom right corner and compare it to the expected
-      // solid green patch.
-      const bottomRightSample = ctx.getImageData(
-          Math.floor(copy.width - sampleWidth),
-          Math.floor(copy.height - sampleHeight),
-          sampleWidth,
-          sampleHeight,
-      );
-      expect(compareColorArrays(bottomRightSample.data, greenPatch)).toEqual(1);
-
-      // Lastly, sample a chunk of the middle of the image and compare it to the
-      // solid magenta patch.
-      const centerSample = ctx.getImageData(
-          Math.floor(copy.width * .5 - sampleWidth * .5),
-          Math.floor(copy.height * .5 - sampleHeight * .5),
-          sampleWidth,
-          sampleHeight,
-      );
-      expect(compareColorArrays(centerSample.data, magentaPatch)).toEqual(1);
-    });
-
-    it('should render normally at devicePixelRatio=1', async () => {
-      const container = document.createElement('div');
-      container.style.width = '100px';
-      container.style.height = '100px';
-      sectionContent.appendChild(container);
-
-      const timingFunctionsShim = new TimingFunctionsShim();
-      timingFunctionsShim.totalElapsedTimeMs = 1234500000;
-
-      const scene = new Scene({
-        container,
-        defaultTransitionTimeMs: 0,
-        desiredSpriteCapacity: 100,
-        devicePixelRatio: 1,
-        timingFunctions: timingFunctionsShim,
-      });
-
-      // Create a Sprite and render it.
-      const sprite = scene.createSprite();
-
-      // Give the Sprite an enter() callback to invoke.
-      sprite.enter((s) => {
-        // Position of the sprite should be centered at world origin.
-        s.PositionWorldX = 0;
-        s.PositionWorldY = 0;
-
-        // Sprite size should fill the canvas.
-        s.SizeWorldWidth = 1;
-        s.SizeWorldHeight = 1;
-
-        // Shape should be a square.
-        s.Sides = 2;
-
-        // Border should be 1/4 of a world unit, half the radius of the
-        // of the shape.
-        s.BorderPlacement = 0;
-        s.BorderRadiusWorld = .25;
-        s.BorderRadiusPixel = 0;
-
-        // Border is opaque green.
-        s.BorderColorR = 0;
-        s.BorderColorG = 255;
-        s.BorderColorB = 0;
-        s.BorderColorOpacity = 1;
-
-        // Interior fill is opaque magenta.
-        s.FillColorR = 255;
-        s.FillColorG = 0;
-        s.FillColorB = 255;
-        s.FillColorOpacity = 1;
-      });
-
-      timingFunctionsShim.runAnimationFrameCallbacks(4);
-
-      // Now, if we inspect the canvas, its pixels should show that the sprite
-      // has been rendered. Start my making a copy of the canvas and for
-      // inspection.
-      const {canvas} = scene;
-      const [copy, ctx, copyContainer] = copyCanvasAndContainer(canvas);
-      sectionContent.appendChild(copyContainer);
-
-      // Grab a snapshot of the Scene's rendered pixels and draw them to
-      // the canvas copy.
-      const blob = await scene[SceneInternalSymbol].snapshot();
-      const img = await blobToImage(blob);
-      ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
-
-      // For integration testing, we'll sample areas of the output that are 10%
-      // the width and height of the canvas size. This patch is a middle-ground
-      // between testing the whole image for pixel-perfect rendering and testing
-      // a single pixel.
-      const sampleWidth = Math.ceil(copy.width * .1);
-      const sampleHeight = Math.ceil(copy.width * .1);
-      const pixelCount = sampleWidth * sampleHeight;
-
-      // Generate patches of solid green and magenta to compare to the rendered
-      // pixels for correctness.
-      const greenPatch = filledColorArray(pixelCount, [0, 255, 0, 255]);
-      const magentaPatch = filledColorArray(pixelCount, [255, 0, 255, 255]);
-
-      // Take a sample of the top left corner and compare it to the expected
-      // solid green patch.
-      const topLeftSample = ctx.getImageData(
-          0,
-          0,
-          sampleWidth,
-          sampleHeight,
-      );
-      expect(compareColorArrays(topLeftSample.data, greenPatch)).toEqual(1);
-
-      // Take a sample of the bottom right corner and compare it to the expected
-      // solid green patch.
-      const bottomRightSample = ctx.getImageData(
-          Math.floor(copy.width - sampleWidth),
-          Math.floor(copy.height - sampleHeight),
-          sampleWidth,
-          sampleHeight,
-      );
-      expect(compareColorArrays(bottomRightSample.data, greenPatch)).toEqual(1);
-
-      // Lastly, sample a chunk of the middle of the image and compare it to the
-      // solid magenta patch.
-      const centerSample = ctx.getImageData(
-          Math.floor(copy.width * .5 - sampleWidth * .5),
-          Math.floor(copy.height * .5 - sampleHeight * .5),
-          sampleWidth,
-          sampleHeight,
-      );
-      expect(compareColorArrays(centerSample.data, magentaPatch)).toEqual(1);
-    });
-
-    it('should render normally at devicePixelRatio=2', async () => {
-      const container = document.createElement('div');
-      container.style.width = '100px';
-      container.style.height = '100px';
-      sectionContent.appendChild(container);
-
-      const timingFunctionsShim = new TimingFunctionsShim();
-      timingFunctionsShim.totalElapsedTimeMs = 1234500000;
-
-      const scene = new Scene({
-        container,
-        defaultTransitionTimeMs: 0,
-        desiredSpriteCapacity: 100,
-        devicePixelRatio: 2,
-        timingFunctions: timingFunctionsShim,
-      });
-
-      // Create a Sprite and render it.
-      const sprite = scene.createSprite();
-
-      // Give the Sprite an enter() callback to invoke.
-      sprite.enter((s) => {
-        // Position of the sprite should be centered at world origin.
-        s.PositionWorldX = 0;
-        s.PositionWorldY = 0;
-
-        // Sprite size should fill the canvas.
-        s.SizeWorldWidth = 1;
-        s.SizeWorldHeight = 1;
-
-        // Shape should be a square.
-        s.Sides = 2;
-
-        // Border should be 1/4 of a world unit, half the radius of the
-        // of the shape.
-        s.BorderPlacement = 0;
-        s.BorderRadiusWorld = .25;
-        s.BorderRadiusPixel = 0;
-
-        // Border is opaque green.
-        s.BorderColorR = 0;
-        s.BorderColorG = 255;
-        s.BorderColorB = 0;
-        s.BorderColorOpacity = 1;
-
-        // Interior fill is opaque magenta.
-        s.FillColorR = 255;
-        s.FillColorG = 0;
-        s.FillColorB = 255;
-        s.FillColorOpacity = 1;
-      });
-
-      timingFunctionsShim.runAnimationFrameCallbacks(4);
-
-      // Now, if we inspect the canvas, its pixels should show that the sprite
-      // has been rendered. Start my making a copy of the canvas and for
-      // inspection.
-      const {canvas} = scene;
-      const [copy, ctx, copyContainer] = copyCanvasAndContainer(canvas);
-      sectionContent.appendChild(copyContainer);
-
-      // Grab a snapshot of the Scene's rendered pixels and draw them to
-      // the canvas copy.
-      const blob = await scene[SceneInternalSymbol].snapshot();
-      const img = await blobToImage(blob);
-      ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
-
-      // For integration testing, we'll sample areas of the output that are 10%
-      // the width and height of the canvas size. This patch is a middle-ground
-      // between testing the whole image for pixel-perfect rendering and testing
-      // a single pixel.
-      const sampleWidth = Math.ceil(copy.width * .1);
-      const sampleHeight = Math.ceil(copy.width * .1);
-      const pixelCount = sampleWidth * sampleHeight;
-
-      // Generate patches of solid green and magenta to compare to the rendered
-      // pixels for correctness.
-      const greenPatch = filledColorArray(pixelCount, [0, 255, 0, 255]);
-      const magentaPatch = filledColorArray(pixelCount, [255, 0, 255, 255]);
-
-      // Take a sample of the top left corner and compare it to the expected
-      // solid green patch.
-      const topLeftSample = ctx.getImageData(
-          0,
-          0,
-          sampleWidth,
-          sampleHeight,
-      );
-      expect(compareColorArrays(topLeftSample.data, greenPatch)).toEqual(1);
-
-      // Take a sample of the bottom right corner and compare it to the expected
-      // solid green patch.
-      const bottomRightSample = ctx.getImageData(
-          Math.floor(copy.width - sampleWidth),
-          Math.floor(copy.height - sampleHeight),
-          sampleWidth,
-          sampleHeight,
-      );
-      expect(compareColorArrays(bottomRightSample.data, greenPatch)).toEqual(1);
-
-      // Lastly, sample a chunk of the middle of the image and compare it to the
-      // solid magenta patch.
-      const centerSample = ctx.getImageData(
-          Math.floor(copy.width * .5 - sampleWidth * .5),
-          Math.floor(copy.height * .5 - sampleHeight * .5),
-          sampleWidth,
-          sampleHeight,
-      );
-      expect(compareColorArrays(centerSample.data, magentaPatch)).toEqual(1);
-    });
-
-    it('should render normally at devicePixelRatio=3', async () => {
-      const container = document.createElement('div');
-      container.style.width = '100px';
-      container.style.height = '100px';
-      sectionContent.appendChild(container);
-
-      const timingFunctionsShim = new TimingFunctionsShim();
-      timingFunctionsShim.totalElapsedTimeMs = 1234500000;
-
-      const scene = new Scene({
-        container,
-        defaultTransitionTimeMs: 0,
-        desiredSpriteCapacity: 100,
-        devicePixelRatio: 3,
-        timingFunctions: timingFunctionsShim,
-      });
-
-      // Create a Sprite and render it.
-      const sprite = scene.createSprite();
-
-      // Give the Sprite an enter() callback to invoke.
-      sprite.enter((s) => {
-        // Position of the sprite should be centered at world origin.
-        s.PositionWorldX = 0;
-        s.PositionWorldY = 0;
-
-        // Sprite size should fill the canvas.
-        s.SizeWorldWidth = 1;
-        s.SizeWorldHeight = 1;
-
-        // Shape should be a square.
-        s.Sides = 2;
-
-        // Border should be 1/4 of a world unit, half the radius of the
-        // of the shape.
-        s.BorderPlacement = 0;
-        s.BorderRadiusWorld = .25;
-        s.BorderRadiusPixel = 0;
-
-        // Border is opaque green.
-        s.BorderColorR = 0;
-        s.BorderColorG = 255;
-        s.BorderColorB = 0;
-        s.BorderColorOpacity = 1;
-
-        // Interior fill is opaque magenta.
-        s.FillColorR = 255;
-        s.FillColorG = 0;
-        s.FillColorB = 255;
-        s.FillColorOpacity = 1;
-      });
-
-      timingFunctionsShim.runAnimationFrameCallbacks(4);
-
-      // Now, if we inspect the canvas, its pixels should show that the sprite
-      // has been rendered. Start my making a copy of the canvas and for
-      // inspection.
-      const {canvas} = scene;
-      const [copy, ctx, copyContainer] = copyCanvasAndContainer(canvas);
-      sectionContent.appendChild(copyContainer);
-
-      // Grab a snapshot of the Scene's rendered pixels and draw them to
-      // the canvas copy.
-      const blob = await scene[SceneInternalSymbol].snapshot();
-      const img = await blobToImage(blob);
-      ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
-
-      // For integration testing, we'll sample areas of the output that are 10%
-      // the width and height of the canvas size. This patch is a middle-ground
-      // between testing the whole image for pixel-perfect rendering and testing
-      // a single pixel.
-      const sampleWidth = Math.ceil(copy.width * .1);
-      const sampleHeight = Math.ceil(copy.width * .1);
-      const pixelCount = sampleWidth * sampleHeight;
-
-      // Generate patches of solid green and magenta to compare to the rendered
-      // pixels for correctness.
-      const greenPatch = filledColorArray(pixelCount, [0, 255, 0, 255]);
-      const magentaPatch = filledColorArray(pixelCount, [255, 0, 255, 255]);
-
-      // Take a sample of the top left corner and compare it to the expected
-      // solid green patch.
-      const topLeftSample = ctx.getImageData(
-          0,
-          0,
-          sampleWidth,
-          sampleHeight,
-      );
-      expect(compareColorArrays(topLeftSample.data, greenPatch)).toEqual(1);
-
-      // Take a sample of the bottom right corner and compare it to the expected
-      // solid green patch.
-      const bottomRightSample = ctx.getImageData(
-          Math.floor(copy.width - sampleWidth),
-          Math.floor(copy.height - sampleHeight),
-          sampleWidth,
-          sampleHeight,
-      );
-      expect(compareColorArrays(bottomRightSample.data, greenPatch)).toEqual(1);
-
-      // Lastly, sample a chunk of the middle of the image and compare it to the
-      // solid magenta patch.
-      const centerSample = ctx.getImageData(
-          Math.floor(copy.width * .5 - sampleWidth * .5),
-          Math.floor(copy.height * .5 - sampleHeight * .5),
-          sampleWidth,
-          sampleHeight,
-      );
-      expect(compareColorArrays(centerSample.data, magentaPatch)).toEqual(1);
-    });
+    }
   });
 });

--- a/test/scene-integration.test.ts
+++ b/test/scene-integration.test.ts
@@ -330,8 +330,8 @@ describe('Scene', () => {
       const sampleHeight = Math.ceil(copy.width * .1);
       const pixelCount = sampleWidth * sampleHeight;
 
-      // Generate patches of solid green and magenta to compare to the rendered
-      // pixels for correctness.
+      // Generate a blank patch and a solid magenta patch to compare to the
+      // rendered pixels for correctness.
       const blankPatch = filledColorArray(pixelCount, [0, 0, 0, 0]);
       const magentaPatch = filledColorArray(pixelCount, [255, 0, 255, 255]);
 
@@ -354,6 +354,576 @@ describe('Scene', () => {
           sampleHeight,
       );
       expect(compareColorArrays(bottomRightSample.data, blankPatch)).toEqual(1);
+
+      // Lastly, sample a chunk of the middle of the image and compare it to the
+      // solid magenta patch.
+      const centerSample = ctx.getImageData(
+          Math.floor(copy.width * .5 - sampleWidth * .5),
+          Math.floor(copy.height * .5 - sampleHeight * .5),
+          sampleWidth,
+          sampleHeight,
+      );
+      expect(compareColorArrays(centerSample.data, magentaPatch)).toEqual(1);
+    });
+
+    it('should render normally after devicePixelRatio change', async () => {
+      const container = document.createElement('div');
+      container.style.width = '100px';
+      container.style.height = '100px';
+      sectionContent.appendChild(container);
+
+      // Initial devicePixelRatio of 2 simulates a retina display.
+      let devicePixelRatio = 2;
+
+      const timingFunctionsShim = new TimingFunctionsShim();
+      timingFunctionsShim.totalElapsedTimeMs = 1234500000;
+
+      const scene = new Scene({
+        container,
+        defaultTransitionTimeMs: 0,
+        desiredSpriteCapacity: 100,
+        devicePixelRatio: () => devicePixelRatio,
+        timingFunctions: timingFunctionsShim,
+      });
+
+      // Create a Sprite and render it.
+      const sprite = scene.createSprite();
+
+      // Give the Sprite an enter() callback to invoke.
+      sprite.enter((s) => {
+        // Position of the sprite should be centered at world origin.
+        s.PositionWorldX = 0;
+        s.PositionWorldY = 0;
+
+        // Sprite size should fill the canvas.
+        s.SizeWorldWidth = 1;
+        s.SizeWorldHeight = 1;
+
+        // Shape should be a square.
+        s.Sides = 2;
+
+        // Border should be 1/4 of a world unit, half the radius of the
+        // of the shape.
+        s.BorderPlacement = 0;
+        s.BorderRadiusWorld = .25;
+        s.BorderRadiusPixel = 0;
+
+        // Border is opaque green.
+        s.BorderColorR = 0;
+        s.BorderColorG = 255;
+        s.BorderColorB = 0;
+        s.BorderColorOpacity = 1;
+
+        // Interior fill is opaque magenta.
+        s.FillColorR = 255;
+        s.FillColorG = 0;
+        s.FillColorB = 255;
+        s.FillColorOpacity = 1;
+      });
+
+      timingFunctionsShim.runAnimationFrameCallbacks(4);
+
+      // Now change the devicePixelRatio and resize(). This simulates moving the
+      // browser to a different monitor with a different devicePixelRatio.
+      devicePixelRatio = 1;
+      scene.resize();
+
+      timingFunctionsShim.runAnimationFrameCallbacks(4);
+
+      // Now, if we inspect the canvas, its pixels should show that the sprite
+      // has been rendered. Start my making a copy of the canvas and for
+      // inspection.
+      const {canvas} = scene;
+      const [copy, ctx, copyContainer] = copyCanvasAndContainer(canvas);
+      sectionContent.appendChild(copyContainer);
+
+      // Grab a snapshot of the Scene's rendered pixels and draw them to
+      // the canvas copy.
+      const blob = await scene[SceneInternalSymbol].snapshot();
+      const img = await blobToImage(blob);
+      ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
+
+      // For integration testing, we'll sample areas of the output that are 10%
+      // the width and height of the canvas size. This patch is a middle-ground
+      // between testing the whole image for pixel-perfect rendering and testing
+      // a single pixel.
+      const sampleWidth = Math.ceil(copy.width * .1);
+      const sampleHeight = Math.ceil(copy.width * .1);
+      const pixelCount = sampleWidth * sampleHeight;
+
+      // Generate patches of solid green and magenta to compare to the rendered
+      // pixels for correctness.
+      const greenPatch = filledColorArray(pixelCount, [0, 255, 0, 255]);
+      const magentaPatch = filledColorArray(pixelCount, [255, 0, 255, 255]);
+
+      // Take a sample of the top left corner and compare it to the expected
+      // solid green patch.
+      const topLeftSample = ctx.getImageData(
+          0,
+          0,
+          sampleWidth,
+          sampleHeight,
+      );
+      expect(compareColorArrays(topLeftSample.data, greenPatch)).toEqual(1);
+
+      // Take a sample of the bottom right corner and compare it to the expected
+      // solid green patch.
+      const bottomRightSample = ctx.getImageData(
+          Math.floor(copy.width - sampleWidth),
+          Math.floor(copy.height - sampleHeight),
+          sampleWidth,
+          sampleHeight,
+      );
+      expect(compareColorArrays(bottomRightSample.data, greenPatch)).toEqual(1);
+
+      // Lastly, sample a chunk of the middle of the image and compare it to the
+      // solid magenta patch.
+      const centerSample = ctx.getImageData(
+          Math.floor(copy.width * .5 - sampleWidth * .5),
+          Math.floor(copy.height * .5 - sampleHeight * .5),
+          sampleWidth,
+          sampleHeight,
+      );
+      expect(compareColorArrays(centerSample.data, magentaPatch)).toEqual(1);
+    });
+  });
+
+  describe('devicePixelRatio', () => {
+    const section = createSection('Scene::devicePixelRatio');
+    const sectionContent = section.querySelector('.content')!;
+
+    it('should render normally at devicePixelRatio=0.5', async () => {
+      const container = document.createElement('div');
+      container.style.width = '100px';
+      container.style.height = '100px';
+      sectionContent.appendChild(container);
+
+      const timingFunctionsShim = new TimingFunctionsShim();
+      timingFunctionsShim.totalElapsedTimeMs = 1234500000;
+
+      const scene = new Scene({
+        container,
+        defaultTransitionTimeMs: 0,
+        desiredSpriteCapacity: 100,
+        devicePixelRatio: 0.5,
+        timingFunctions: timingFunctionsShim,
+      });
+
+      // Create a Sprite and render it.
+      const sprite = scene.createSprite();
+
+      // Give the Sprite an enter() callback to invoke.
+      sprite.enter((s) => {
+        // Position of the sprite should be centered at world origin.
+        s.PositionWorldX = 0;
+        s.PositionWorldY = 0;
+
+        // Sprite size should fill the canvas.
+        s.SizeWorldWidth = 1;
+        s.SizeWorldHeight = 1;
+
+        // Shape should be a square.
+        s.Sides = 2;
+
+        // Border should be 1/4 of a world unit, half the radius of the
+        // of the shape.
+        s.BorderPlacement = 0;
+        s.BorderRadiusWorld = .25;
+        s.BorderRadiusPixel = 0;
+
+        // Border is opaque green.
+        s.BorderColorR = 0;
+        s.BorderColorG = 255;
+        s.BorderColorB = 0;
+        s.BorderColorOpacity = 1;
+
+        // Interior fill is opaque magenta.
+        s.FillColorR = 255;
+        s.FillColorG = 0;
+        s.FillColorB = 255;
+        s.FillColorOpacity = 1;
+      });
+
+      timingFunctionsShim.runAnimationFrameCallbacks(4);
+
+      // Now, if we inspect the canvas, its pixels should show that the sprite
+      // has been rendered. Start my making a copy of the canvas and for
+      // inspection.
+      const {canvas} = scene;
+      const [copy, ctx, copyContainer] = copyCanvasAndContainer(canvas);
+      sectionContent.appendChild(copyContainer);
+
+      // Grab a snapshot of the Scene's rendered pixels and draw them to
+      // the canvas copy.
+      const blob = await scene[SceneInternalSymbol].snapshot();
+      const img = await blobToImage(blob);
+      ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
+
+      // For integration testing, we'll sample areas of the output that are 10%
+      // the width and height of the canvas size. This patch is a middle-ground
+      // between testing the whole image for pixel-perfect rendering and testing
+      // a single pixel.
+      const sampleWidth = Math.ceil(copy.width * .1);
+      const sampleHeight = Math.ceil(copy.width * .1);
+      const pixelCount = sampleWidth * sampleHeight;
+
+      // Generate patches of solid green and magenta to compare to the rendered
+      // pixels for correctness.
+      const greenPatch = filledColorArray(pixelCount, [0, 255, 0, 255]);
+      const magentaPatch = filledColorArray(pixelCount, [255, 0, 255, 255]);
+
+      // Take a sample of the top left corner and compare it to the expected
+      // solid green patch.
+      const topLeftSample = ctx.getImageData(
+          0,
+          0,
+          sampleWidth,
+          sampleHeight,
+      );
+      expect(compareColorArrays(topLeftSample.data, greenPatch)).toEqual(1);
+
+      // Take a sample of the bottom right corner and compare it to the expected
+      // solid green patch.
+      const bottomRightSample = ctx.getImageData(
+          Math.floor(copy.width - sampleWidth),
+          Math.floor(copy.height - sampleHeight),
+          sampleWidth,
+          sampleHeight,
+      );
+      expect(compareColorArrays(bottomRightSample.data, greenPatch)).toEqual(1);
+
+      // Lastly, sample a chunk of the middle of the image and compare it to the
+      // solid magenta patch.
+      const centerSample = ctx.getImageData(
+          Math.floor(copy.width * .5 - sampleWidth * .5),
+          Math.floor(copy.height * .5 - sampleHeight * .5),
+          sampleWidth,
+          sampleHeight,
+      );
+      expect(compareColorArrays(centerSample.data, magentaPatch)).toEqual(1);
+    });
+
+    it('should render normally at devicePixelRatio=1', async () => {
+      const container = document.createElement('div');
+      container.style.width = '100px';
+      container.style.height = '100px';
+      sectionContent.appendChild(container);
+
+      const timingFunctionsShim = new TimingFunctionsShim();
+      timingFunctionsShim.totalElapsedTimeMs = 1234500000;
+
+      const scene = new Scene({
+        container,
+        defaultTransitionTimeMs: 0,
+        desiredSpriteCapacity: 100,
+        devicePixelRatio: 1,
+        timingFunctions: timingFunctionsShim,
+      });
+
+      // Create a Sprite and render it.
+      const sprite = scene.createSprite();
+
+      // Give the Sprite an enter() callback to invoke.
+      sprite.enter((s) => {
+        // Position of the sprite should be centered at world origin.
+        s.PositionWorldX = 0;
+        s.PositionWorldY = 0;
+
+        // Sprite size should fill the canvas.
+        s.SizeWorldWidth = 1;
+        s.SizeWorldHeight = 1;
+
+        // Shape should be a square.
+        s.Sides = 2;
+
+        // Border should be 1/4 of a world unit, half the radius of the
+        // of the shape.
+        s.BorderPlacement = 0;
+        s.BorderRadiusWorld = .25;
+        s.BorderRadiusPixel = 0;
+
+        // Border is opaque green.
+        s.BorderColorR = 0;
+        s.BorderColorG = 255;
+        s.BorderColorB = 0;
+        s.BorderColorOpacity = 1;
+
+        // Interior fill is opaque magenta.
+        s.FillColorR = 255;
+        s.FillColorG = 0;
+        s.FillColorB = 255;
+        s.FillColorOpacity = 1;
+      });
+
+      timingFunctionsShim.runAnimationFrameCallbacks(4);
+
+      // Now, if we inspect the canvas, its pixels should show that the sprite
+      // has been rendered. Start my making a copy of the canvas and for
+      // inspection.
+      const {canvas} = scene;
+      const [copy, ctx, copyContainer] = copyCanvasAndContainer(canvas);
+      sectionContent.appendChild(copyContainer);
+
+      // Grab a snapshot of the Scene's rendered pixels and draw them to
+      // the canvas copy.
+      const blob = await scene[SceneInternalSymbol].snapshot();
+      const img = await blobToImage(blob);
+      ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
+
+      // For integration testing, we'll sample areas of the output that are 10%
+      // the width and height of the canvas size. This patch is a middle-ground
+      // between testing the whole image for pixel-perfect rendering and testing
+      // a single pixel.
+      const sampleWidth = Math.ceil(copy.width * .1);
+      const sampleHeight = Math.ceil(copy.width * .1);
+      const pixelCount = sampleWidth * sampleHeight;
+
+      // Generate patches of solid green and magenta to compare to the rendered
+      // pixels for correctness.
+      const greenPatch = filledColorArray(pixelCount, [0, 255, 0, 255]);
+      const magentaPatch = filledColorArray(pixelCount, [255, 0, 255, 255]);
+
+      // Take a sample of the top left corner and compare it to the expected
+      // solid green patch.
+      const topLeftSample = ctx.getImageData(
+          0,
+          0,
+          sampleWidth,
+          sampleHeight,
+      );
+      expect(compareColorArrays(topLeftSample.data, greenPatch)).toEqual(1);
+
+      // Take a sample of the bottom right corner and compare it to the expected
+      // solid green patch.
+      const bottomRightSample = ctx.getImageData(
+          Math.floor(copy.width - sampleWidth),
+          Math.floor(copy.height - sampleHeight),
+          sampleWidth,
+          sampleHeight,
+      );
+      expect(compareColorArrays(bottomRightSample.data, greenPatch)).toEqual(1);
+
+      // Lastly, sample a chunk of the middle of the image and compare it to the
+      // solid magenta patch.
+      const centerSample = ctx.getImageData(
+          Math.floor(copy.width * .5 - sampleWidth * .5),
+          Math.floor(copy.height * .5 - sampleHeight * .5),
+          sampleWidth,
+          sampleHeight,
+      );
+      expect(compareColorArrays(centerSample.data, magentaPatch)).toEqual(1);
+    });
+
+    it('should render normally at devicePixelRatio=2', async () => {
+      const container = document.createElement('div');
+      container.style.width = '100px';
+      container.style.height = '100px';
+      sectionContent.appendChild(container);
+
+      const timingFunctionsShim = new TimingFunctionsShim();
+      timingFunctionsShim.totalElapsedTimeMs = 1234500000;
+
+      const scene = new Scene({
+        container,
+        defaultTransitionTimeMs: 0,
+        desiredSpriteCapacity: 100,
+        devicePixelRatio: 2,
+        timingFunctions: timingFunctionsShim,
+      });
+
+      // Create a Sprite and render it.
+      const sprite = scene.createSprite();
+
+      // Give the Sprite an enter() callback to invoke.
+      sprite.enter((s) => {
+        // Position of the sprite should be centered at world origin.
+        s.PositionWorldX = 0;
+        s.PositionWorldY = 0;
+
+        // Sprite size should fill the canvas.
+        s.SizeWorldWidth = 1;
+        s.SizeWorldHeight = 1;
+
+        // Shape should be a square.
+        s.Sides = 2;
+
+        // Border should be 1/4 of a world unit, half the radius of the
+        // of the shape.
+        s.BorderPlacement = 0;
+        s.BorderRadiusWorld = .25;
+        s.BorderRadiusPixel = 0;
+
+        // Border is opaque green.
+        s.BorderColorR = 0;
+        s.BorderColorG = 255;
+        s.BorderColorB = 0;
+        s.BorderColorOpacity = 1;
+
+        // Interior fill is opaque magenta.
+        s.FillColorR = 255;
+        s.FillColorG = 0;
+        s.FillColorB = 255;
+        s.FillColorOpacity = 1;
+      });
+
+      timingFunctionsShim.runAnimationFrameCallbacks(4);
+
+      // Now, if we inspect the canvas, its pixels should show that the sprite
+      // has been rendered. Start my making a copy of the canvas and for
+      // inspection.
+      const {canvas} = scene;
+      const [copy, ctx, copyContainer] = copyCanvasAndContainer(canvas);
+      sectionContent.appendChild(copyContainer);
+
+      // Grab a snapshot of the Scene's rendered pixels and draw them to
+      // the canvas copy.
+      const blob = await scene[SceneInternalSymbol].snapshot();
+      const img = await blobToImage(blob);
+      ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
+
+      // For integration testing, we'll sample areas of the output that are 10%
+      // the width and height of the canvas size. This patch is a middle-ground
+      // between testing the whole image for pixel-perfect rendering and testing
+      // a single pixel.
+      const sampleWidth = Math.ceil(copy.width * .1);
+      const sampleHeight = Math.ceil(copy.width * .1);
+      const pixelCount = sampleWidth * sampleHeight;
+
+      // Generate patches of solid green and magenta to compare to the rendered
+      // pixels for correctness.
+      const greenPatch = filledColorArray(pixelCount, [0, 255, 0, 255]);
+      const magentaPatch = filledColorArray(pixelCount, [255, 0, 255, 255]);
+
+      // Take a sample of the top left corner and compare it to the expected
+      // solid green patch.
+      const topLeftSample = ctx.getImageData(
+          0,
+          0,
+          sampleWidth,
+          sampleHeight,
+      );
+      expect(compareColorArrays(topLeftSample.data, greenPatch)).toEqual(1);
+
+      // Take a sample of the bottom right corner and compare it to the expected
+      // solid green patch.
+      const bottomRightSample = ctx.getImageData(
+          Math.floor(copy.width - sampleWidth),
+          Math.floor(copy.height - sampleHeight),
+          sampleWidth,
+          sampleHeight,
+      );
+      expect(compareColorArrays(bottomRightSample.data, greenPatch)).toEqual(1);
+
+      // Lastly, sample a chunk of the middle of the image and compare it to the
+      // solid magenta patch.
+      const centerSample = ctx.getImageData(
+          Math.floor(copy.width * .5 - sampleWidth * .5),
+          Math.floor(copy.height * .5 - sampleHeight * .5),
+          sampleWidth,
+          sampleHeight,
+      );
+      expect(compareColorArrays(centerSample.data, magentaPatch)).toEqual(1);
+    });
+
+    it('should render normally at devicePixelRatio=3', async () => {
+      const container = document.createElement('div');
+      container.style.width = '100px';
+      container.style.height = '100px';
+      sectionContent.appendChild(container);
+
+      const timingFunctionsShim = new TimingFunctionsShim();
+      timingFunctionsShim.totalElapsedTimeMs = 1234500000;
+
+      const scene = new Scene({
+        container,
+        defaultTransitionTimeMs: 0,
+        desiredSpriteCapacity: 100,
+        devicePixelRatio: 3,
+        timingFunctions: timingFunctionsShim,
+      });
+
+      // Create a Sprite and render it.
+      const sprite = scene.createSprite();
+
+      // Give the Sprite an enter() callback to invoke.
+      sprite.enter((s) => {
+        // Position of the sprite should be centered at world origin.
+        s.PositionWorldX = 0;
+        s.PositionWorldY = 0;
+
+        // Sprite size should fill the canvas.
+        s.SizeWorldWidth = 1;
+        s.SizeWorldHeight = 1;
+
+        // Shape should be a square.
+        s.Sides = 2;
+
+        // Border should be 1/4 of a world unit, half the radius of the
+        // of the shape.
+        s.BorderPlacement = 0;
+        s.BorderRadiusWorld = .25;
+        s.BorderRadiusPixel = 0;
+
+        // Border is opaque green.
+        s.BorderColorR = 0;
+        s.BorderColorG = 255;
+        s.BorderColorB = 0;
+        s.BorderColorOpacity = 1;
+
+        // Interior fill is opaque magenta.
+        s.FillColorR = 255;
+        s.FillColorG = 0;
+        s.FillColorB = 255;
+        s.FillColorOpacity = 1;
+      });
+
+      timingFunctionsShim.runAnimationFrameCallbacks(4);
+
+      // Now, if we inspect the canvas, its pixels should show that the sprite
+      // has been rendered. Start my making a copy of the canvas and for
+      // inspection.
+      const {canvas} = scene;
+      const [copy, ctx, copyContainer] = copyCanvasAndContainer(canvas);
+      sectionContent.appendChild(copyContainer);
+
+      // Grab a snapshot of the Scene's rendered pixels and draw them to
+      // the canvas copy.
+      const blob = await scene[SceneInternalSymbol].snapshot();
+      const img = await blobToImage(blob);
+      ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
+
+      // For integration testing, we'll sample areas of the output that are 10%
+      // the width and height of the canvas size. This patch is a middle-ground
+      // between testing the whole image for pixel-perfect rendering and testing
+      // a single pixel.
+      const sampleWidth = Math.ceil(copy.width * .1);
+      const sampleHeight = Math.ceil(copy.width * .1);
+      const pixelCount = sampleWidth * sampleHeight;
+
+      // Generate patches of solid green and magenta to compare to the rendered
+      // pixels for correctness.
+      const greenPatch = filledColorArray(pixelCount, [0, 255, 0, 255]);
+      const magentaPatch = filledColorArray(pixelCount, [255, 0, 255, 255]);
+
+      // Take a sample of the top left corner and compare it to the expected
+      // solid green patch.
+      const topLeftSample = ctx.getImageData(
+          0,
+          0,
+          sampleWidth,
+          sampleHeight,
+      );
+      expect(compareColorArrays(topLeftSample.data, greenPatch)).toEqual(1);
+
+      // Take a sample of the bottom right corner and compare it to the expected
+      // solid green patch.
+      const bottomRightSample = ctx.getImageData(
+          Math.floor(copy.width - sampleWidth),
+          Math.floor(copy.height - sampleHeight),
+          sampleWidth,
+          sampleHeight,
+      );
+      expect(compareColorArrays(bottomRightSample.data, greenPatch)).toEqual(1);
 
       // Lastly, sample a chunk of the middle of the image and compare it to the
       // solid magenta patch.


### PR DESCRIPTION
Fixes #44:

- Bug fix: use `devicePixelRatio` when computing viewMatrix and viewScale uniforms for vertex shader.
- Expose an optional Scene constructor setting for making `devicePixelRatio` a specific number or a callback function which will be invoked to determine the `devicePixelRatio` on resize.
- Update `resize()` logic to incorporate changes to `devicePixelRatio`.
- Add `devicePixelRatio` setting in the debugging demo for manual testing.
- Add karma unit tests for `devicePixelRatio` values of 0.5, 1, 2 and 3, and dynamically changing between 2 and 1.