### PR TITLE
Fix hit test devicePixelRatio bug

### DIFF
--- a/karma.conf.ts
+++ b/karma.conf.ts
@@ -24,7 +24,7 @@ module.exports = (config) => {
     basePath: '',
 
     // Frameworks to use.
-    frameworks: ['jasmine'],
+    frameworks: ['jasmine', 'webpack'],
 
     // List of files / patterns to load in the browser.
     files: ['test/**/*.test.ts'],

--- a/src/lib/commands/setup-draw-command.ts
+++ b/src/lib/commands/setup-draw-command.ts
@@ -34,6 +34,7 @@ interface CoordinatorAPI {
   attributeMapper: AttributeMapper;
   canvas: HTMLCanvasElement;
   elapsedTimeMs: () => number;
+  getDevicePixelRatio: () => number;
   getProjectionMatrix: (context: ReglContext) => number[];
   getViewMatrix: () => number[];
   getViewMatrixScale: () => number[];
@@ -110,6 +111,7 @@ export function setupDrawCommand(
 
     'uniforms': {
       'ts': () => coordinator.elapsedTimeMs(),
+      'devicePixelRatio': () => coordinator.getDevicePixelRatio(),
       'instanceCount': () => coordinator.instanceCount,
       'orderZGranularity': () => coordinator.orderZGranularity,
       'viewMatrix': () => coordinator.getViewMatrix(),

--- a/src/lib/commands/setup-hit-test-command.ts
+++ b/src/lib/commands/setup-hit-test-command.ts
@@ -31,6 +31,7 @@ import {fragmentShader, vertexShader} from '../shaders/hit-test-shaders';
 interface CoordinatorAPI {
   attributeMapper: AttributeMapper;
   elapsedTimeMs: () => number;
+  getDevicePixelRatio: () => number;
   getViewMatrix: () => number[];
   getViewMatrixScale: () => number[];
   hitTestAttributeMapper: AttributeMapper;
@@ -95,6 +96,7 @@ export function setupHitTestCommand(coordinator: CoordinatorAPI): () => void {
     'uniforms': {
       'ts': () => coordinator.elapsedTimeMs(),
       'capacity': () => coordinator.hitTestAttributeMapper.totalSwatches,
+      'devicePixelRatio': () => coordinator.getDevicePixelRatio(),
       'hitTestCoordinates': () => ([
         coordinator.hitTestParameters.x,
         coordinator.hitTestParameters.y,

--- a/src/lib/commands/setup-hit-test-command.ts
+++ b/src/lib/commands/setup-hit-test-command.ts
@@ -100,10 +100,11 @@ export function setupHitTestCommand(coordinator: CoordinatorAPI): () => void {
       'hitTestCoordinates': () => ([
         coordinator.hitTestParameters.x,
         coordinator.hitTestParameters.y,
-        coordinator.hitTestParameters.width,
-        coordinator.hitTestParameters.height,
+        coordinator.hitTestParameters.width || 0,
+        coordinator.hitTestParameters.height || 0,
       ]),
-      'inclusive': () => !!coordinator.hitTestParameters.inclusive,
+      'inclusive': () => coordinator.hitTestParameters === undefined ||
+          !!coordinator.hitTestParameters.inclusive,
       'viewMatrix': () => coordinator.getViewMatrix(),
       'viewMatrixScale': () => coordinator.getViewMatrixScale(),
       'targetValuesTexture': coordinator.targetValuesTexture,

--- a/src/lib/scene-internal.ts
+++ b/src/lib/scene-internal.ts
@@ -705,7 +705,7 @@ export class SceneInternal implements Renderer {
   /**
    * Wrap lookups for devicePixelRatio to satisfy aggressive compilation.
    */
-  private getDevicePixelRatio(): number {
+  getDevicePixelRatio(): number {
     return typeof window !== 'undefined' ? window.devicePixelRatio || 1 : 1;
   }
 

--- a/src/lib/shaders/hit-test-shaders.ts
+++ b/src/lib/shaders/hit-test-shaders.ts
@@ -182,9 +182,11 @@ void main () {
   readInputTexels();
 
   // Compute time variables.
-  rangeT = clamp(
-      range(previousTransitionTimeMs(), targetTransitionTimeMs(), ts),
-      0., 1.);
+  rangeT =
+    ts >= targetTransitionTimeMs() ? 1. :
+    ts <= previousTransitionTimeMs() ? 0. :
+    clamp(range(previousTransitionTimeMs(), targetTransitionTimeMs(), ts),
+        0., 1.);
   easeT = cubicEaseInOut(rangeT);
 
   // Compute current size component values by interpolation (parallelized).

--- a/src/lib/shaders/hit-test-shaders.ts
+++ b/src/lib/shaders/hit-test-shaders.ts
@@ -82,6 +82,8 @@ precision lowp float;
 
 uniform float ts;
 
+uniform float devicePixelRatio;
+
 /**
  * Screen pixel coordinates for performing the hit test. The XY channels contain
  * the screen x and y coordinates respectively. The ZW channels hold the width
@@ -236,7 +238,7 @@ void main () {
       currentPositionPixel,
       vec2(-.5, -.5),
       viewMatrix
-  ) * .25;
+  ) * .5 / devicePixelRatio;
   vec2 topRight = computeViewVertexPosition(
       currentPositionWorld,
       computedSize,
@@ -244,7 +246,7 @@ void main () {
       currentPositionPixel,
       vec2(.5, .5),
       viewMatrix
-  ) * .25;
+  ) * .5 / devicePixelRatio;
   vec4 spriteBox = vec4(bottomLeft.xy, topRight.xy - bottomLeft.xy);
 
   // Hit test coordinates are presented based on the top-left corner, so to

--- a/src/lib/shaders/scene-fragment-shader.ts
+++ b/src/lib/shaders/scene-fragment-shader.ts
@@ -42,7 +42,7 @@ export function fragmentShader() {
 precision lowp float;
 
 /**
- * Each sprite receieves the same vertex coordinates, which describe a unit
+ * Each sprite receives the same vertex coordinates, which describe a unit
  * square centered at the origin. However, the distance calculations performed
  * by the fragment shader use a distance of 1 to mean the dead center of a
  * circle, which implies a diameter of 2. So to convert from sprite vertex

--- a/src/lib/shaders/scene-fragment-shader.ts
+++ b/src/lib/shaders/scene-fragment-shader.ts
@@ -42,6 +42,15 @@ export function fragmentShader() {
 precision lowp float;
 
 /**
+ * Each sprite receieves the same vertex coordinates, which describe a unit
+ * square centered at the origin. However, the distance calculations performed
+ * by the fragment shader use a distance of 1 to mean the dead center of a
+ * circle, which implies a diameter of 2. So to convert from sprite vertex
+ * coordinate space to edge distance space requires a dilation of 2.
+ */
+const float EDGE_DISTANCE_DILATION = 2.;
+
+/**
  * View matrix for converting from world space to clip space.
  */
 uniform mat3 viewMatrix;
@@ -65,7 +74,7 @@ varying vec4 varyingVertexCoordinates;
 
 /**
  * Threshold distance values to consider the pixel outside the shape (X) or
- * inside the shape (Y). Values between constitue the borde.
+ * inside the shape (Y). Values between constitute the border.
  */
 varying vec2 varyingBorderThresholds;
 
@@ -162,7 +171,8 @@ float getDistStar(int sides, vec4 radii) {
 
   // The point of interest starts with the varyingVertexCoordinates, but shifted
   // to center the shape vertically.
-  vec2 poi = 2. * varyingVertexCoordinates.xy + vec2(0., 2. - height);
+  vec2 poi = EDGE_DISTANCE_DILATION * varyingVertexCoordinates.xy +
+    vec2(0., EDGE_DISTANCE_DILATION - height);
 
   // Compute theta for point of interest, counter-clockwise from vertical.
   float theta = computeTheta(poi);
@@ -235,7 +245,7 @@ float getDistEllipse() {
   vec4 aspectRatio = flipped ? varyingAspectRatio.yxwz : varyingAspectRatio;
 
   // Point of interest in the expanded circle (before aspect ratio stretching).
-  vec2 circlePoint = 2. * abs(
+  vec2 circlePoint = EDGE_DISTANCE_DILATION * abs(
       flipped ? varyingVertexCoordinates.yx : varyingVertexCoordinates.xy);
 
   // Capture length for inside/outside checking.
@@ -280,7 +290,7 @@ float getDistRect() {
   // All quadrants can be treated the same, so we limit our computation to the
   // top right.
   vec2 ar = varyingAspectRatio.xy;
-  vec2 p = ar * 2. * abs(varyingVertexCoordinates.xy);
+  vec2 p = ar * EDGE_DISTANCE_DILATION * abs(varyingVertexCoordinates.xy);
 
   // If the point of intrest is beyond the top corner, return the negative
   // distance to that corner.
@@ -306,7 +316,7 @@ float getDistSDF(vec4 shapeTexture) {
   vec2 textureUv =
       shapeTexture.xy +
       shapeTexture.zw * varyingVertexCoordinates.zw;
-  return 2. * texture2D(sdfTexture, textureUv).z - 1.;
+  return EDGE_DISTANCE_DILATION * texture2D(sdfTexture, textureUv).z - 1.;
 }
 
 /**

--- a/src/lib/shaders/scene-vertex-shader.ts
+++ b/src/lib/shaders/scene-vertex-shader.ts
@@ -67,6 +67,11 @@ precision lowp float;
 uniform float ts;
 
 /**
+ * Effective devicePixelRatio.
+ */
+uniform float devicePixelRatio;
+
+/**
  * Total number of sprite instances being rendered this pass. Used to compute
  * clip-space Z for stacking sprites based on their instanceIndex.
  * This ensures that partial-opacity pixels of stacked sprites will be
@@ -137,7 +142,7 @@ varying vec4 varyingVertexCoordinates;
 
 /**
  * Threshold distance values to consider the pixel outside the shape (X) or
- * inside the shape (Y). Values between constitue the borde.
+ * inside the shape (Y). Values between constitute the border.
  */
 varying vec2 varyingBorderThresholds;
 
@@ -297,15 +302,20 @@ void main () {
         targetBorderRadiusPixel(),
         targetBorderPlacement())
   );
+  float currentBorderRadiusWorld = borderProperties.x;
+  float currentBorderRadiusPixel = borderProperties.y;
+  float currentBorderPlacement = borderProperties.z;
 
   // The fragment shader needs to know the threshold signed distances that
   // indicate whether each pixel is inside the shape, in the boreder, or outside
   // of the shape.
   vec2 projectedSizePixel = computedSize.xy * viewMatrixScale.xy;
-  float edgeDistance = borderProperties.x +
-    borderProperties.y * 8. / min(projectedSizePixel.x, projectedSizePixel.y);
+  float edgeDistance = currentBorderRadiusWorld + (
+      currentBorderRadiusPixel * 4. * devicePixelRatio /
+      min(projectedSizePixel.x, projectedSizePixel.y)
+    );
   varyingBorderThresholds =
-    vec2(0., edgeDistance) + mix(0., -edgeDistance, borderProperties.z);
+    vec2(0., edgeDistance) + mix(0., -edgeDistance, currentBorderPlacement);
 
   // Compute the sprite's aspect ratio and the inverse.
   varyingAspectRatio = computeAspectRatio(computedSize);

--- a/src/lib/shaders/scene-vertex-shader.ts
+++ b/src/lib/shaders/scene-vertex-shader.ts
@@ -69,7 +69,7 @@ precision lowp float;
 const float CLIP_SPACE_RANGE = 2.;
 
 /**
- * Each sprite receieves the same vertex coordinates, which describe a unit
+ * Each sprite receives the same vertex coordinates, which describe a unit
  * square centered at the origin. However, the distance calculations performed
  * by the fragment shader use a distance of 1 to mean the dead center of a
  * circle, which implies a diameter of 2. So to convert from sprite vertex

--- a/test/scene-integration.test.ts
+++ b/test/scene-integration.test.ts
@@ -515,4 +515,113 @@ describe('Scene', () => {
       });
     }
   });
+
+  describe('hitTest()', () => {
+    const section = createSection('Scene::hitTest');
+    const sectionContent = section.querySelector('.content')!;
+
+    for (let devicePixelRatio = 1; devicePixelRatio <= 3;
+         devicePixelRatio += 0.5) {
+      describe(`devicePixelRatio=${devicePixelRatio}`, () => {
+        const container = document.createElement('div');
+        container.style.width = '200px';
+        container.style.height = '200px';
+        sectionContent.appendChild(container);
+
+        const timingFunctionsShim = new TimingFunctionsShim();
+
+        const scene = new Scene({
+          container,
+          defaultTransitionTimeMs: 0,
+          desiredSpriteCapacity: 10,
+          devicePixelRatio,
+          timingFunctions: timingFunctionsShim,
+        });
+
+        // Create four overlapping sprites.
+        const sprites = [
+          [-.2, .2],   // Index 0 = Top left.
+          [.2, .2],    // Index 1 = Top right.
+          [-.2, -.2],  // Index 2 = Bottom left.
+          [.2, -.2],   // Index 3 = Bottom right.
+        ].map((position) => {
+          const sprite = scene.createSprite();
+          sprite.enter((s: SpriteView) => {
+            s.BorderColorOpacity = .4;
+            s.BorderRadiusPixel = 10;
+            s.FillColor = [255, 255, 255, .4];
+            s.PositionWorld = position;
+            s.Sides = 1;
+            s.SizeWorld = .8;
+          })
+          return sprite;
+        });
+        timingFunctionsShim.runAnimationFrameCallbacks(3);
+
+        // Grid of nine tests, like a tic-tac-toe board.
+        const tests = [
+          // Top row.
+          {
+            label: 'top left',
+            params: {x: 10, y: 10, width: 0, height: 0, inclusive: true},
+            expected: [0, -1, -1, -1],
+          },
+          {
+            label: 'top center',
+            params: {x: 100, y: 10, width: 0, height: 0, inclusive: true},
+            expected: [0, 1, -1, -1],
+          },
+          {
+            label: 'top right',
+            params: {x: 190, y: 10, width: 0, height: 0, inclusive: true},
+            expected: [-1, 1, -1, -1],
+          },
+
+          // Middle row.
+          {
+            label: 'middle left',
+            params: {x: 10, y: 100, width: 0, height: 0, inclusive: true},
+            expected: [0, -1, 2, -1],
+          },
+          {
+            label: 'middle center',
+            params: {x: 100, y: 100, width: 0, height: 0, inclusive: true},
+            expected: [0, 1, 2, 3],
+          },
+          {
+            label: 'middle right',
+            params: {x: 190, y: 100, width: 0, height: 0, inclusive: true},
+            expected: [-1, 1, -1, 3],
+          },
+
+          // Bottom row.
+          {
+            label: 'bottom left',
+            params: {x: 10, y: 190, width: 0, height: 0, inclusive: true},
+            expected: [-1, -1, 2, -1],
+          },
+          {
+            label: 'bottom center',
+            params: {x: 100, y: 190, width: 0, height: 0, inclusive: true},
+            expected: [-1, -1, 2, 3],
+          },
+          {
+            label: 'bottom right',
+            params: {x: 190, y: 190, width: 0, height: 0, inclusive: true},
+            expected: [-1, -1, -1, 3],
+          },
+        ];
+
+        for (const {label, params, expected} of tests) {
+          it(`should hit ${label}`, () => {
+            const res = scene.hitTest({...params, sprites});
+            expect(res[0]).toBeCloseTo(expected[0], 0);
+            expect(res[1]).toBeCloseTo(expected[1], 0);
+            expect(res[2]).toBeCloseTo(expected[2], 0);
+            expect(res[3]).toBeCloseTo(expected[3], 0);
+          });
+        }
+      });
+    }
+  });
 });

--- a/test/scene-integration.test.ts
+++ b/test/scene-integration.test.ts
@@ -528,8 +528,8 @@ describe('Scene', () => {
     }
   });
 
-  describe('hitTest()', () => {
-    const section = createSection('Scene::hitTest');
+  describe('hitTest() inclusive', () => {
+    const section = createSection('Scene::hitTest() inclusive');
     const sectionContent = section.querySelector('.content')!;
 
     for (let devicePixelRatio = 1; devicePixelRatio <= 3;
@@ -612,6 +612,101 @@ describe('Scene', () => {
           {
             params: {x: 190, y: 190, width: 0, height: 0, inclusive: true},
             expected: [-1, -1, -1, 3],
+          },
+        ];
+
+        for (const {params, expected} of tests) {
+          const res = scene.hitTest({...params, sprites});
+          expect(res[0]).toBeCloseTo(expected[0], 0);
+          expect(res[1]).toBeCloseTo(expected[1], 0);
+          expect(res[2]).toBeCloseTo(expected[2], 0);
+          expect(res[3]).toBeCloseTo(expected[3], 0);
+        }
+
+        // Cleanup REGL resources.
+        scene[SceneInternalSymbol].regl.destroy();
+      });
+    }
+  });
+
+  describe('hitTest() exclusive', () => {
+    const section = createSection('Scene::hitTest() exclusive');
+    const sectionContent = section.querySelector('.content')!;
+
+    for (let devicePixelRatio = 1; devicePixelRatio <= 3;
+         devicePixelRatio += 0.5) {
+      it(`should hit when devicePixelRatio=${devicePixelRatio}`, () => {
+        const container = document.createElement('div');
+        container.style.width = '200px';
+        container.style.height = '200px';
+        sectionContent.appendChild(container);
+
+        const timingFunctionsShim = new TimingFunctionsShim();
+
+        const scene = new Scene({
+          container,
+          defaultTransitionTimeMs: 0,
+          desiredSpriteCapacity: 10,
+          devicePixelRatio,
+          timingFunctions: timingFunctionsShim,
+        });
+
+        // Create four overlapping sprites.
+        const sprites = [
+          [-.25, .25],   // Index 0 = Top left.
+          [.25, .25],    // Index 1 = Top right.
+          [-.25, -.25],  // Index 2 = Bottom left.
+          [.25, -.25],   // Index 3 = Bottom right.
+        ].map((position) => {
+          const sprite = scene.createSprite();
+          sprite.enter((s: SpriteView) => {
+            s.BorderColorOpacity = .4;
+            s.BorderRadiusPixel = 10;
+            s.FillColor = [255, 255, 255, .4];
+            s.PositionWorld = position;
+            s.Sides = 1;
+            s.SizeWorld = .4;
+          })
+          return sprite;
+        });
+        timingFunctionsShim.runAnimationFrameCallbacks(3);
+
+        // Grid of nine tests, like a tic-tac-toe board.
+        const tests = [
+          // Top row.
+          {
+            params: {x: 5, y: 5, width: 190, height: 90, inclusive: false},
+            expected: [0, 1, -1, -1],
+          },
+          // Middle row.
+          {
+            params: {x: 5, y: 55, width: 190, height: 90, inclusive: false},
+            expected: [-1, -1, -1, -1],
+          },
+          // Bottom row.
+          {
+            params: {x: 5, y: 105, width: 190, height: 90, inclusive: false},
+            expected: [-1, -1, 2, 3],
+          },
+          // Left column.
+          {
+            params: {x: 5, y: 5, width: 90, height: 190, inclusive: false},
+            expected: [0, -1, 2, -1],
+          },
+          // Center column.
+          {
+            params: {x: 55, y: 5, width: 90, height: 190, inclusive: false},
+            expected: [-1, -1, -1, -1],
+          },
+          // Right column.
+          {
+            params: {x: 105, y: 5, width: 90, height: 190, inclusive: false},
+            expected: [-1, 1, -1, 3],
+          },
+          // All.
+          {
+            params: {x: 5, y: 5, width: 190, height: 190, inclusive: false},
+            expected: [0, 1, 2, 3],
           },
         ];
 

--- a/test/scene-integration.test.ts
+++ b/test/scene-integration.test.ts
@@ -243,6 +243,9 @@ describe('Scene', () => {
           sampleHeight,
       );
       expect(compareColorArrays(centerSample.data, magentaPatch)).toEqual(1);
+
+      // Release REGL resources.
+      scene[SceneInternalSymbol].regl.destroy();
     });
   });
 });
@@ -335,6 +338,9 @@ describe('Scene', () => {
           sampleHeight,
       );
       expect(compareColorArrays(centerSample.data, magentaPatch)).toEqual(1);
+
+      // Release REGL resources.
+      scene[SceneInternalSymbol].regl.destroy();
     });
 
     it('should render normally after devicePixelRatio change', async () => {
@@ -424,6 +430,9 @@ describe('Scene', () => {
           sampleHeight,
       );
       expect(compareColorArrays(centerSample.data, magentaPatch)).toEqual(1);
+
+      // Release REGL resources.
+      scene[SceneInternalSymbol].regl.destroy();
     });
   });
 
@@ -512,6 +521,9 @@ describe('Scene', () => {
             sampleHeight,
         );
         expect(compareColorArrays(centerSample.data, magentaPatch)).toEqual(1);
+
+        // Release REGL resources.
+        scene[SceneInternalSymbol].regl.destroy();
       });
     }
   });
@@ -522,7 +534,7 @@ describe('Scene', () => {
 
     for (let devicePixelRatio = 1; devicePixelRatio <= 3;
          devicePixelRatio += 0.5) {
-      describe(`devicePixelRatio=${devicePixelRatio}`, () => {
+      it(`should hit when devicePixelRatio=${devicePixelRatio}`, () => {
         const container = document.createElement('div');
         container.style.width = '200px';
         container.style.height = '200px';
@@ -562,65 +574,57 @@ describe('Scene', () => {
         const tests = [
           // Top row.
           {
-            label: 'top left',
             params: {x: 10, y: 10, width: 0, height: 0, inclusive: true},
             expected: [0, -1, -1, -1],
           },
           {
-            label: 'top center',
             params: {x: 100, y: 10, width: 0, height: 0, inclusive: true},
             expected: [0, 1, -1, -1],
           },
           {
-            label: 'top right',
             params: {x: 190, y: 10, width: 0, height: 0, inclusive: true},
             expected: [-1, 1, -1, -1],
           },
 
           // Middle row.
           {
-            label: 'middle left',
             params: {x: 10, y: 100, width: 0, height: 0, inclusive: true},
             expected: [0, -1, 2, -1],
           },
           {
-            label: 'middle center',
             params: {x: 100, y: 100, width: 0, height: 0, inclusive: true},
             expected: [0, 1, 2, 3],
           },
           {
-            label: 'middle right',
             params: {x: 190, y: 100, width: 0, height: 0, inclusive: true},
             expected: [-1, 1, -1, 3],
           },
 
           // Bottom row.
           {
-            label: 'bottom left',
             params: {x: 10, y: 190, width: 0, height: 0, inclusive: true},
             expected: [-1, -1, 2, -1],
           },
           {
-            label: 'bottom center',
             params: {x: 100, y: 190, width: 0, height: 0, inclusive: true},
             expected: [-1, -1, 2, 3],
           },
           {
-            label: 'bottom right',
             params: {x: 190, y: 190, width: 0, height: 0, inclusive: true},
             expected: [-1, -1, -1, 3],
           },
         ];
 
-        for (const {label, params, expected} of tests) {
-          it(`should hit ${label}`, () => {
-            const res = scene.hitTest({...params, sprites});
-            expect(res[0]).toBeCloseTo(expected[0], 0);
-            expect(res[1]).toBeCloseTo(expected[1], 0);
-            expect(res[2]).toBeCloseTo(expected[2], 0);
-            expect(res[3]).toBeCloseTo(expected[3], 0);
-          });
+        for (const {params, expected} of tests) {
+          const res = scene.hitTest({...params, sprites});
+          expect(res[0]).toBeCloseTo(expected[0], 0);
+          expect(res[1]).toBeCloseTo(expected[1], 0);
+          expect(res[2]).toBeCloseTo(expected[2], 0);
+          expect(res[3]).toBeCloseTo(expected[3], 0);
         }
+
+        // Cleanup REGL resources.
+        scene[SceneInternalSymbol].regl.destroy();
       });
     }
   });

--- a/test/scene.test.ts
+++ b/test/scene.test.ts
@@ -83,6 +83,11 @@ describe('Scene', () => {
     timingFunctions: timingFunctionsShim,
   });
 
+  // Cleanup REGL resources after tests complete.
+  afterAll(() => {
+    scene[SceneInternalSymbol].regl.destroy();
+  });
+
   describe('constructor', () => {
     it('should create a canvas', () => {
       const devicePixelRatio = window.devicePixelRatio || 1;

--- a/test/selection.test.ts
+++ b/test/selection.test.ts
@@ -19,6 +19,7 @@
  */
 
 import {Scene} from '../src/lib/scene';
+import {SceneInternalSymbol} from '../src/lib/symbols';
 import {TimingFunctionsShim} from '../src/lib/timing-functions-shim';
 
 /**
@@ -72,19 +73,27 @@ describe('Selection', () => {
   container.style.height = '100px';
   content.appendChild(container);
 
-  const timingFunctionsShim = new TimingFunctionsShim();
-
-  timingFunctionsShim.totalElapsedTimeMs = 1000;
-
-  const scene = new Scene({
-    container,
-    defaultTransitionTimeMs: 0,
-    desiredSpriteCapacity: 100,
-    timingFunctions: timingFunctionsShim,
-  });
 
   describe('init', () => {
-    it('should invoke callback asynchronously after bind', async () => {
+    let timingFunctionsShim: TimingFunctionsShim;
+    let scene: Scene;
+
+    beforeEach(() => {
+      timingFunctionsShim = new TimingFunctionsShim();
+      timingFunctionsShim.totalElapsedTimeMs = 1000;
+      scene = new Scene({
+        container,
+        defaultTransitionTimeMs: 0,
+        desiredSpriteCapacity: 100,
+        timingFunctions: timingFunctionsShim,
+      });
+    });
+
+    afterEach(() => {
+      scene[SceneInternalSymbol].regl.destroy();
+    });
+
+    it('should invoke callback asynchronously after bind', () => {
       const selection = scene.createSelection<TestDatum>();
 
       // Keep track of how many times the init callback is invoked.
@@ -124,7 +133,7 @@ describe('Selection', () => {
       expect(initDataSet).toEqual(expectedDataSet);
     });
 
-    it('should invoke init before enter', async () => {
+    it('should invoke init before enter', () => {
       const selection = scene.createSelection<TestDatum>();
 
       // Log invocations of callbacks to test for order later.
@@ -177,7 +186,25 @@ describe('Selection', () => {
   });
 
   describe('enter', () => {
-    it('should invoke callback asynchronously after bind', async () => {
+    let timingFunctionsShim: TimingFunctionsShim;
+    let scene: Scene;
+
+    beforeEach(() => {
+      timingFunctionsShim = new TimingFunctionsShim();
+      timingFunctionsShim.totalElapsedTimeMs = 1000;
+      scene = new Scene({
+        container,
+        defaultTransitionTimeMs: 0,
+        desiredSpriteCapacity: 100,
+        timingFunctions: timingFunctionsShim,
+      });
+    });
+
+    afterEach(() => {
+      scene[SceneInternalSymbol].regl.destroy();
+    });
+
+    it('should invoke callback asynchronously after bind', () => {
       const selection = scene.createSelection<TestDatum>();
 
       // Keep track of how many times the enter callback is invoked.
@@ -217,7 +244,7 @@ describe('Selection', () => {
       expect(enterDataSet).toEqual(expectedDataSet);
     });
 
-    it('should invoke enter before update', async () => {
+    it('should invoke enter before update', () => {
       const selection = scene.createSelection<TestDatum>();
 
       // Log invocations of callbacks to test for order later.
@@ -272,7 +299,25 @@ describe('Selection', () => {
   });
 
   describe('update', () => {
-    it('should invoke callback asynchronously after re-bind', async () => {
+    let timingFunctionsShim: TimingFunctionsShim;
+    let scene: Scene;
+
+    beforeEach(() => {
+      timingFunctionsShim = new TimingFunctionsShim();
+      timingFunctionsShim.totalElapsedTimeMs = 1000;
+      scene = new Scene({
+        container,
+        defaultTransitionTimeMs: 0,
+        desiredSpriteCapacity: 100,
+        timingFunctions: timingFunctionsShim,
+      });
+    });
+
+    afterEach(() => {
+      scene[SceneInternalSymbol].regl.destroy();
+    });
+
+    it('should invoke callback asynchronously after re-bind', () => {
       const selection = scene.createSelection<TestDatum>();
 
       // Keep track of how many times the enter callback is invoked.
@@ -325,7 +370,7 @@ describe('Selection', () => {
       expect(updateDataSet).toEqual(expectedDataSet);
     });
 
-    it('should invoke update before exit', async () => {
+    it('should invoke update before exit', () => {
       const selection = scene.createSelection<TestDatum>();
 
       // Log invocations of callbacks to test for order later.
@@ -392,7 +437,25 @@ describe('Selection', () => {
   });
 
   describe('bind', () => {
-    it('should invoke callback asynchronously after bind', async () => {
+    let timingFunctionsShim: TimingFunctionsShim;
+    let scene: Scene;
+
+    beforeEach(() => {
+      timingFunctionsShim = new TimingFunctionsShim();
+      timingFunctionsShim.totalElapsedTimeMs = 1000;
+      scene = new Scene({
+        container,
+        defaultTransitionTimeMs: 0,
+        desiredSpriteCapacity: 100,
+        timingFunctions: timingFunctionsShim,
+      });
+    });
+
+    afterEach(() => {
+      scene[SceneInternalSymbol].regl.destroy();
+    });
+
+    it('should invoke callback asynchronously after bind', () => {
       const selection = scene.createSelection<TestDatum>();
 
       // Keep track of how many times the bind callback is invoked.
@@ -432,7 +495,7 @@ describe('Selection', () => {
       expect(bindDataSet).toEqual(expectedDataSet);
     });
 
-    it('should invoke bind before init', async () => {
+    it('should invoke bind before init', () => {
       const selection = scene.createSelection<TestDatum>();
 
       // Log invocations of callbacks to test for order later.
@@ -475,7 +538,25 @@ describe('Selection', () => {
   });
 
   describe('clear', () => {
-    it('should remove data and sprites', async () => {
+    let timingFunctionsShim: TimingFunctionsShim;
+    let scene: Scene;
+
+    beforeEach(() => {
+      timingFunctionsShim = new TimingFunctionsShim();
+      timingFunctionsShim.totalElapsedTimeMs = 1000;
+      scene = new Scene({
+        container,
+        defaultTransitionTimeMs: 0,
+        desiredSpriteCapacity: 100,
+        timingFunctions: timingFunctionsShim,
+      });
+    });
+
+    afterEach(() => {
+      scene[SceneInternalSymbol].regl.destroy();
+    });
+
+    it('should remove data and sprites', () => {
       const selection = scene.createSelection<TestDatum>();
 
       // Keep track of how many times the various callbacks are invoked.
@@ -550,7 +631,7 @@ describe('Selection', () => {
       expect(counter).toEqual({bind: 3, init: 1, enter: 1, exit: 1});
     });
 
-    it('should finish before a subsequent bind', async () => {
+    it('should finish before a subsequent bind', () => {
       const selection = scene.createSelection<TestDatum>();
 
       // Keep track of how many times the various callbacks are invoked.
@@ -623,7 +704,7 @@ describe('Selection', () => {
       expect(counter).toEqual({bind: 5, init: 2, enter: 2, update: 0, exit: 1});
     });
 
-    it('should circumvent a scheduled bind', async () => {
+    it('should circumvent a scheduled bind', () => {
       const selection = scene.createSelection<TestDatum>();
 
       // Keep track of how many times the various callbacks are invoked.


### PR DESCRIPTION
Fixes:

* Tests are now immune to WebGL context loss due to too many contexts. #48
* `hitTest()` now works for `devicePixelRatio` other than 2. #49
* Fixes previously undisclosed bug in border radius computation for `devicePixelRatio` other than 2.
* Implements unit tests for Scene `hitTest()` method.