### PR TITLE
Fix external border rendering and rename BorderRadiusWorld to BorderRadiusRelative

### DIFF
--- a/src/demo/debugging-demo.ts
+++ b/src/demo/debugging-demo.ts
@@ -67,7 +67,7 @@ function main() {
     transitionTimeMs: 2000,
     paddingPx: 0,
     maxBatchTimeMs: 20,
-    borderRadiusWorld: 0.25,
+    borderRadiusRelative: 0.25,
     borderRadiusPx: 0.25,
     borderPlacement: 0,
     positionRelative: 0,
@@ -168,7 +168,7 @@ function main() {
       const color = d3.color('' + colorScale(j * count + i)) as d3.RGBColor;
 
       s.BorderRadiusPixel = settings.borderRadiusPx;
-      s.BorderRadiusRelative = settings.borderRadiusWorld;
+      s.BorderRadiusRelative = settings.borderRadiusRelative;
 
       s.BorderColor = hoveredIndices.has(index) ? hoverColor : borderColor;
 
@@ -236,7 +236,7 @@ function main() {
   gui.add(settings, 'maxBatchTimeMs', 1, 1000, 1).onChange(() => {
     workScheduler.maxWorkTimeMs = settings.maxBatchTimeMs;
   });
-  gui.add(settings, 'borderRadiusWorld', 0, 1, .05).onChange(update);
+  gui.add(settings, 'borderRadiusRelative', 0, 1, .05).onChange(update);
   gui.add(settings, 'borderRadiusPx', 0, 100, 1).onChange(update);
   gui.add(settings, 'borderPlacement', 0, 1, .1).onChange(update);
   gui.add(settings, 'positionRelative', -3, 3, .1).onChange(update);

--- a/src/demo/debugging-demo.ts
+++ b/src/demo/debugging-demo.ts
@@ -167,8 +167,8 @@ function main() {
       const j = Math.floor(index / count);
       const color = d3.color('' + colorScale(j * count + i)) as d3.RGBColor;
 
-      s.BorderRadiusWorld = settings.borderRadiusWorld;
       s.BorderRadiusPixel = settings.borderRadiusPx;
+      s.BorderRadiusRelative = settings.borderRadiusWorld;
 
       s.BorderColor = hoveredIndices.has(index) ? hoverColor : borderColor;
 

--- a/src/demo/text-demo.ts
+++ b/src/demo/text-demo.ts
@@ -79,6 +79,7 @@ function main() {
   const settings = {
     transitionTimeMs: 250,
     borderPlacement: 1,
+    borderRadiusRelative: .1,
     maxBatchTimeMs: 20,
     align: 'left' as AlignmentOption,
     verticalAlign: 'middle' as VerticalAlignmentOption,
@@ -187,8 +188,6 @@ function main() {
       s.SizeWorldWidth = .1;
       s.SizeWorldHeight = .1;
 
-      s.BorderRadiusRelative = .2;
-
       s.BorderColorOpacity = 0;
       s.FillColorOpacity = 0;
     });
@@ -206,6 +205,7 @@ function main() {
       s.PositionWorld = d;
 
       s.BorderPlacement = settings.borderPlacement;
+      s.BorderRadiusRelative = settings.borderRadiusRelative;
 
       s.BorderColor = borderColor;
       s.FillColor = fillColor;
@@ -228,6 +228,7 @@ function main() {
     workScheduler.maxWorkTimeMs = settings.maxBatchTimeMs;
   });
   gui.add(settings, 'borderPlacement', 0, 1, .1).onChange(update);
+  gui.add(settings, 'borderRadiusRelative', 0, 1, .1).onChange(update);
   gui.add(settings, 'align', ['left', 'center', 'right']).onChange(update);
   gui.add(settings, 'verticalAlign', ['top', 'middle', 'bottom'])
       .onChange(update);

--- a/src/demo/text-demo.ts
+++ b/src/demo/text-demo.ts
@@ -187,7 +187,7 @@ function main() {
       s.SizeWorldWidth = .1;
       s.SizeWorldHeight = .1;
 
-      s.BorderRadiusWorld = .2;
+      s.BorderRadiusRelative = .2;
 
       s.BorderColorOpacity = 0;
       s.FillColorOpacity = 0;

--- a/src/lib/commands/setup-draw-command.ts
+++ b/src/lib/commands/setup-draw-command.ts
@@ -88,12 +88,12 @@ export function setupDrawCommand(
     'vert': vertexShader(coordinator.attributeMapper),
 
     'attributes': {
-      // Corners and uv coords of the rectangle, same for each sprite.
+      // Corners of the rectangle, same for each sprite.
       'vertexCoordinates': [
-        [-0.5, -0.5, 0, 1],
-        [0.5, -0.5, 1, 1],
-        [-0.5, 0.5, 0, 0],
-        [0.5, 0.5, 1, 0],
+        [-0.5, -0.5],  // UV: [0, 1].
+        [0.5, -0.5],   // UV: [1, 1].
+        [-0.5, 0.5],   // UV: [0, 0].
+        [0.5, 0.5],    // UV: [1, 0].
       ],
 
       // Swatch uv coordinates for retrieving data texture values.

--- a/src/lib/generated/sprite-view-impl.ts
+++ b/src/lib/generated/sprite-view-impl.ts
@@ -313,25 +313,25 @@ export class SpriteViewImpl implements SpriteView {
     this[DataViewSymbol][22] = attributeValue;
   }
 
-  get BorderRadiusWorld(): number {
-    return this[DataViewSymbol][23];
-  }
-
-  set BorderRadiusWorld(attributeValue: number) {
-    if (isNaN(attributeValue)) {
-      throw new RangeError('BorderRadiusWorld cannot be NaN');
-    }
-
-    this[DataViewSymbol][23] = attributeValue;
-  }
-
   get BorderRadiusPixel(): number {
-    return this[DataViewSymbol][24];
+    return this[DataViewSymbol][23];
   }
 
   set BorderRadiusPixel(attributeValue: number) {
     if (isNaN(attributeValue)) {
       throw new RangeError('BorderRadiusPixel cannot be NaN');
+    }
+
+    this[DataViewSymbol][23] = attributeValue;
+  }
+
+  get BorderRadiusRelative(): number {
+    return this[DataViewSymbol][24];
+  }
+
+  set BorderRadiusRelative(attributeValue: number) {
+    if (isNaN(attributeValue)) {
+      throw new RangeError('BorderRadiusRelative cannot be NaN');
     }
 
     this[DataViewSymbol][24] = attributeValue;

--- a/src/lib/generated/sprite-view.d.ts
+++ b/src/lib/generated/sprite-view.d.ts
@@ -42,8 +42,8 @@ export interface SpriteView {
   ShapeTextureV: number;
   ShapeTextureWidth: number;
   ShapeTextureHeight: number;
-  BorderRadiusWorld: number;
   BorderRadiusPixel: number;
+  BorderRadiusRelative: number;
   BorderPlacement: number;
   BorderColorR: number;
   BorderColorG: number;

--- a/src/lib/glyph-mapper.ts
+++ b/src/lib/glyph-mapper.ts
@@ -61,11 +61,11 @@ export const DEFAULT_GLYPH_MAPPER_SETTINGS: GlyphMapperSettings =
     Object.freeze({
       maxTextureSize: 2048,
       fontSize: DEFAULT_GLYPH_FONT_SIZE_PX,
-      buffer: Math.ceil(DEFAULT_GLYPH_FONT_SIZE_PX / 4),
+      buffer: DEFAULT_GLYPH_FONT_SIZE_PX,
       radius: DEFAULT_GLYPH_FONT_SIZE_PX,
       // This default value ensures that a distance of zero coincides with the
       // edge of the glyph.
-      cutoff: 0.5,
+      cutoff: 1,
       fontFamily: 'monospace',
       fontWeight: 'normal',
     });
@@ -217,12 +217,12 @@ export class GlyphMapper {
       }
     }
 
-    const coordinates = {
+    const coordinates = Object.freeze({
       u: col / this.glyphsPerRow,
       v: row / this.glyphsPerRow,
       width: this.glyphSize / this.textureSize,
       height: this.glyphSize / this.textureSize,
-    };
+    });
     this.glyphToCoordinates.set(glyph, coordinates);
 
     return coordinates;

--- a/src/lib/shaders/hit-test-shaders.ts
+++ b/src/lib/shaders/hit-test-shaders.ts
@@ -80,6 +80,22 @@ export function vertexShader(
   return glsl`
 precision lowp float;
 
+/**
+ * WebGL vertex shaders output coordinates in clip space, which is a 3D volume
+ * where each component is clipped to the range (-1,1). The distance from
+ * edge-to-edge is therefore 2.
+ */
+const float CLIP_SPACE_RANGE = 2.;
+
+/**
+ * Each sprite receives the same vertex coordinates, which describe a unit
+ * square centered at the origin. However, the distance calculations performed
+ * by the fragment shader use a distance of 1 to mean the dead center of a
+ * circle, which implies a diameter of 2. So to convert from sprite vertex
+ * coordinate space to edge distance space requires a dilation of 2.
+ */
+const float EDGE_DISTANCE_DILATION = 2.;
+
 uniform float ts;
 
 uniform float devicePixelRatio;
@@ -215,6 +231,47 @@ void main () {
     currentMinSizePixel
   );
 
+  // Compute border attributes in parallel.
+  vec3 borderProperties = computeCurrentValue(
+      vec3(
+        previousBorderRadiusPixel(),
+        previousBorderRadiusRelative(),
+        previousBorderPlacement()),
+      vec3(
+        previousBorderRadiusPixelDelta(),
+        previousBorderRadiusRelativeDelta(),
+        previousBorderPlacementDelta()),
+      vec3(
+        targetBorderRadiusPixel(),
+        targetBorderRadiusRelative(),
+        targetBorderPlacement())
+  );
+  float currentBorderRadiusPixel = borderProperties.x;
+  float currentBorderRadiusRelative = borderProperties.y;
+  float currentBorderPlacement = borderProperties.z;
+
+  // Project the computed size into pixels by using the viewMatrixScale. Note
+  // that this already includes the effect of the devicePixelRatio, and a 2x
+  // multiplier for clip-space, which goes from -1 to 1 in all dimensions.
+  vec2 projectedSizePixel = computedSize.xy * viewMatrixScale.xy;
+
+  // Compute the distance from the sprite edge to the extent of the border. Used
+  // to shift the corners before hit testing to make sure the bounding box
+  // includes borders outside of the shape.
+  float edgeDistance = currentBorderRadiusRelative + (
+      currentBorderRadiusPixel *
+      CLIP_SPACE_RANGE *
+      EDGE_DISTANCE_DILATION *
+      devicePixelRatio /
+      min(projectedSizePixel.x, projectedSizePixel.y)
+    );
+
+  // Shift coorner vertices outward to account for borders, which may expand
+  // the bounding box of the sprite. XY are the bottom left corner, ZW are for
+  // the top right.
+  vec4 cornerCoordinates = vec4(-.5, -.5, .5, .5) *
+    (1. + edgeDistance * currentBorderPlacement);
+
   // Compute the current position component attributes.
   vec2 currentPositionPixel = computeCurrentValue(
       previousPositionPixel(),
@@ -238,7 +295,7 @@ void main () {
       computedSize,
       currentPositionRelative,
       currentPositionPixel,
-      vec2(-.5, -.5),
+      cornerCoordinates.xy,
       viewMatrix
   ) * .5 / devicePixelRatio;
   vec2 topRight = computeViewVertexPosition(
@@ -246,7 +303,7 @@ void main () {
       computedSize,
       currentPositionRelative,
       currentPositionPixel,
-      vec2(.5, .5),
+      cornerCoordinates.zw,
       viewMatrix
   ) * .5 / devicePixelRatio;
   vec4 spriteBox = vec4(bottomLeft.xy, topRight.xy - bottomLeft.xy);

--- a/src/lib/shaders/scene-fragment-shader.ts
+++ b/src/lib/shaders/scene-fragment-shader.ts
@@ -70,7 +70,7 @@ varying float varyingT;
  * Interpolated, per-vertex coordinate attributes for the quad into which the
  * sprite will be rendered.
  */
-varying vec4 varyingVertexCoordinates;
+varying vec2 varyingVertexCoordinates;
 
 /**
  * Threshold distance values to consider the pixel outside the shape (X) or
@@ -171,7 +171,7 @@ float getDistStar(int sides, vec4 radii) {
 
   // The point of interest starts with the varyingVertexCoordinates, but shifted
   // to center the shape vertically.
-  vec2 poi = EDGE_DISTANCE_DILATION * varyingVertexCoordinates.xy +
+  vec2 poi = EDGE_DISTANCE_DILATION * varyingVertexCoordinates +
     vec2(0., EDGE_DISTANCE_DILATION - height);
 
   // Compute theta for point of interest, counter-clockwise from vertical.
@@ -246,7 +246,7 @@ float getDistEllipse() {
 
   // Point of interest in the expanded circle (before aspect ratio stretching).
   vec2 circlePoint = EDGE_DISTANCE_DILATION * abs(
-      flipped ? varyingVertexCoordinates.yx : varyingVertexCoordinates.xy);
+      flipped ? varyingVertexCoordinates.yx : varyingVertexCoordinates);
 
   // Capture length for inside/outside checking.
   float len = length(circlePoint);
@@ -290,7 +290,7 @@ float getDistRect() {
   // All quadrants can be treated the same, so we limit our computation to the
   // top right.
   vec2 ar = varyingAspectRatio.xy;
-  vec2 p = ar * EDGE_DISTANCE_DILATION * abs(varyingVertexCoordinates.xy);
+  vec2 p = ar * EDGE_DISTANCE_DILATION * abs(varyingVertexCoordinates);
 
   // If the point of intrest is beyond the top corner, return the negative
   // distance to that corner.
@@ -320,9 +320,12 @@ float getDistRect() {
  * texture within which to sample (corresponds to the glyph being rendered).
  */
 float getDistSDF(vec4 shapeTexture) {
+  // UV sampling coordinates are Y-flipped and shifted.
+  vec2 coordUV = varyingVertexCoordinates * vec2(1., -1.) + .5;
+
   vec2 textureUv =
       shapeTexture.xy +
-      shapeTexture.zw * varyingVertexCoordinates.zw;
+      shapeTexture.zw * coordUV;
   return EDGE_DISTANCE_DILATION * texture2D(sdfTexture, textureUv).z - 1.;
 }
 

--- a/src/lib/shaders/scene-fragment-shader.ts
+++ b/src/lib/shaders/scene-fragment-shader.ts
@@ -294,8 +294,15 @@ float getDistRect() {
 
   // If the point of intrest is beyond the top corner, return the negative
   // distance to that corner.
-  if (all(greaterThan(p, ar))) {
+  bvec2 gt = greaterThan(p, ar);
+  if (all(gt)) {
     return -distance(p, ar);
+  }
+  if (gt.x) {
+    return ar.x - p.x;
+  }
+  if (gt.y) {
+    return ar.y - p.y;
   }
 
   // Determine distance to nearest edge.

--- a/src/lib/shaders/scene-vertex-shader.ts
+++ b/src/lib/shaders/scene-vertex-shader.ts
@@ -36,8 +36,7 @@
  * However, a couple of things make Scene unique:
  *  - We need to interpolate to find the instantaneous positions.
  *  - Many properties are specified in both world and pixel coordinates.
- *  - The only 'local' coordinates are the vertexCoordinates.xy, and these are
- *    already also world coordinates.
+ *  - The only 'local' coordinates are the vertexCoordinates.
  *  - Producing world coordinates is an algebraic operation combining the
  *    vertex coordinates with instance offsets and dimensions.
  *
@@ -126,18 +125,17 @@ uniform sampler2D targetValuesTexture;
 /**
  * Per-vertex coordinates for the quad into which the sprite will be rendered.
  * XY contain the local cartesian coordinates for a unit square centered at the
- * origin. The ZW coordinates contain the y-flipped UV coordinates for orienting
- * the square against texture atlases.
+ * origin.
  *
  *   vertexCoordinates: [
- *     [-0.5, -0.5, 0, 1],
- *     [0.5, -0.5, 1, 1],
- *     [-0.5, 0.5, 0, 0],
- *     [0.5, 0.5, 1, 0],
+ *     [-0.5, -0.5],
+ *     [0.5, -0.5],
+ *     [-0.5, 0.5],
+ *     [0.5, 0.5],
  *   ],
  *
  */
-attribute vec4 vertexCoordinates;
+attribute vec2 vertexCoordinates;
 
 /**
  * Instanced, per-sprite index and UV coordinates of the sprite's data swatch.
@@ -154,7 +152,7 @@ varying float varyingT;
 /**
  * Interpolated vertexCoordinates for fragment shader.
  */
-varying vec4 varyingVertexCoordinates;
+varying vec2 varyingVertexCoordinates;
 
 /**
  * Threshold distance values to consider the pixel outside the shape (X) or
@@ -344,7 +342,7 @@ void main () {
 
   // Shift the quad vertices outward to account for borders, which may expand
   // the bounding box of the sprite.
-  varyingVertexCoordinates.xy *= (1. - varyingBorderThresholds.x);
+  varyingVertexCoordinates *= (1. - varyingBorderThresholds.x);
 
   // Compute the sprite's aspect ratio and the inverse.
   varyingAspectRatio = computeAspectRatio(computedSize);
@@ -371,7 +369,7 @@ void main () {
       computedSize,
       currentPositionRelative,
       currentPositionPixel,
-      varyingVertexCoordinates.xy,
+      varyingVertexCoordinates,
       viewMatrix
   );
 

--- a/src/lib/shaders/scene-vertex-shader.ts
+++ b/src/lib/shaders/scene-vertex-shader.ts
@@ -342,6 +342,10 @@ void main () {
   varyingBorderThresholds =
     vec2(0., edgeDistance) + mix(0., -edgeDistance, currentBorderPlacement);
 
+  // Shift the quad vertices outward to account for borders, which may expand
+  // the bounding box of the sprite.
+  varyingVertexCoordinates.xy *= (1. - varyingBorderThresholds.x);
+
   // Compute the sprite's aspect ratio and the inverse.
   varyingAspectRatio = computeAspectRatio(computedSize);
 
@@ -367,7 +371,7 @@ void main () {
       computedSize,
       currentPositionRelative,
       currentPositionPixel,
-      vertexCoordinates.xy,
+      varyingVertexCoordinates.xy,
       viewMatrix
   );
 

--- a/src/lib/shaders/scene-vertex-shader.ts
+++ b/src/lib/shaders/scene-vertex-shader.ts
@@ -306,20 +306,20 @@ void main () {
   // Compute border attributes in parallel.
   vec3 borderProperties = computeCurrentValue(
       vec3(
-        previousBorderRadiusWorld(),
         previousBorderRadiusPixel(),
+        previousBorderRadiusRelative(),
         previousBorderPlacement()),
       vec3(
-        previousBorderRadiusWorldDelta(),
         previousBorderRadiusPixelDelta(),
+        previousBorderRadiusRelativeDelta(),
         previousBorderPlacementDelta()),
       vec3(
-        targetBorderRadiusWorld(),
         targetBorderRadiusPixel(),
+        targetBorderRadiusRelative(),
         targetBorderPlacement())
   );
-  float currentBorderRadiusWorld = borderProperties.x;
-  float currentBorderRadiusPixel = borderProperties.y;
+  float currentBorderRadiusPixel = borderProperties.x;
+  float currentBorderRadiusRelative = borderProperties.y;
   float currentBorderPlacement = borderProperties.z;
 
   // Project the computed size into pixels by using the viewMatrixScale. Note
@@ -332,7 +332,7 @@ void main () {
   // of the shape. A point right on the edge of the shape will have a distance
   // of 0. In edge-distance space, a distance of 1 would be the dead center of a
   // circle.
-  float edgeDistance = currentBorderRadiusWorld + (
+  float edgeDistance = currentBorderRadiusRelative + (
       currentBorderRadiusPixel *
       CLIP_SPACE_RANGE *
       EDGE_DISTANCE_DILATION *

--- a/src/lib/sprite-attributes.ts
+++ b/src/lib/sprite-attributes.ts
@@ -253,15 +253,17 @@ export const SPRITE_ATTRIBUTES: readonly SpriteAttribute[] = [
   },
 
   /**
-   * The border can have width in both world and pixel coordinates. These
-   * are additive.
+   * The border can have width in both pixel coordinates, and relative to the
+   * size of the sprite (width or height, whichever is smaller). These are
+   * additive. Note that the size of the border does not affect the size of the
+   * sprite, so there is no conflict here.
    */
   {
-    attributeName: 'BorderRadiusWorld',
+    attributeName: 'BorderRadiusPixel',
     isInterpolable: true,
   },
   {
-    attributeName: 'BorderRadiusPixel',
+    attributeName: 'BorderRadiusRelative',
     isInterpolable: true,
   },
 

--- a/test/glyph-integration.test.ts
+++ b/test/glyph-integration.test.ts
@@ -1,0 +1,168 @@
+/**
+ * @license
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * @fileoverview Integration test for rendering glyphs of text.
+ */
+
+import {Scene} from '../src/lib/scene';
+import {SceneInternalSymbol} from '../src/lib/symbols';
+import {TimingFunctionsShim} from '../src/lib/timing-functions-shim';
+
+import {blobToImage, compareColorArrays, copyCanvasAndContainer, createSection, filledColorArray} from './utils';
+
+/**
+ * Tests produce visible artifacts for debugging.
+ */
+const article = document.createElement('article');
+article.className = 'cw';
+article.innerHTML = `
+<style>
+.cw {
+  font-family: monospace;
+}
+.cw .content {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+}
+.cw canvas {
+  background-image: linear-gradient(135deg, #aaa 50%, #ccc 50%);
+  background-size: 10px 10px;
+  box-shadow: inset 0 0 0 1px rgba(0,0,0,0.25);
+}
+</style>
+`;
+document.body.appendChild(article);
+
+describe('glyph', () => {
+  it('should render a glyph of text', async () => {
+    // Create a <section> for storing visible artifacts.
+    const section = createSection('glyph');
+    article.appendChild(section);
+
+    const content = section.querySelector('.content')!;
+
+    // Create a container <div> of fixed size for the Scene to render into.
+    const container = document.createElement('div');
+    container.style.width = '40px';
+    container.style.height = '40px';
+    content.appendChild(container);
+
+    const timingFunctionsShim = new TimingFunctionsShim();
+    timingFunctionsShim.totalElapsedTimeMs = 1000;
+
+    // For testing purposes, the glyph we render is a solid square character,
+    // Unicode code point U+25A0.
+    const scene = new Scene({
+      container,
+      defaultTransitionTimeMs: 0,
+      desiredSpriteCapacity: 1,
+      glyphs: `\u25a0`,  // Black Square.
+      timingFunctions: timingFunctionsShim,
+    });
+
+    const glyphMapper = scene[SceneInternalSymbol].glyphMapper;
+    const glyphs = glyphMapper.glyphs;
+
+    const glyph = glyphs[0];
+    const coords = glyphMapper.getGlyph(glyph);
+
+    if (!coords) {
+      throw new Error('Coordinates for glyph could not be found');
+    }
+
+    const sprite = scene.createSprite();
+
+    // Give the Sprite an enter() callback to invoke.
+    sprite.enter((s) => {
+      s.PositionWorld = [.15, 0];
+      s.SizeWorld = 1;
+
+      // Shape should sample from SDF.
+      s.Sides = 0;
+      s.ShapeTexture = coords;
+
+      // Border should be equal to size of sprite, entirely outside.
+      s.BorderPlacement = 1;
+      s.BorderRadiusRelative = 1;
+
+      // Blue border, yellow fill.
+      s.BorderColor = [0, 0, 255, 1];
+      s.FillColor = [255, 255, 0, 1];
+    });
+
+    timingFunctionsShim.runAnimationFrameCallbacks(4);
+
+    // Now, if we inspect the canvas, its pixels should show that the sprite
+    // has been rendered. Start my making a copy of the canvas and for
+    // inspection.
+    const {canvas} = scene;
+    const [copy, ctx, copyContainer] = copyCanvasAndContainer(canvas);
+    content.appendChild(copyContainer);
+
+    // Grab a snapshot of the Scene's rendered pixels and draw them to
+    // the canvas copy.
+    const blob = await scene[SceneInternalSymbol].snapshot();
+    const img = await blobToImage(blob);
+    ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
+
+    // For integration testing, we'll sample an area of the output that's 10%
+    // the width and height of the canvas size. This patch is a middle-ground
+    // between testing the whole image for pixel-perfect rendering and testing
+    // a single pixel.
+    const sampleWidth = Math.ceil(copy.width * .1);
+    const sampleHeight = Math.ceil(copy.width * .1);
+    const pixelCount = sampleWidth * sampleHeight;
+
+    // Generate patches of solid green and magenta to compare to the rendered
+    // pixels for correctness.
+    const solidBlue = filledColorArray(pixelCount, [0, 0, 255, 255]);
+    const solidYellow = filledColorArray(pixelCount, [255, 255, 0, 255]);
+
+    // Take a sample of the top left corner and compare it to the expected
+    // solid green patch.
+    const topLeftSample = ctx.getImageData(
+        0,
+        0,
+        sampleWidth,
+        sampleHeight,
+    );
+    expect(compareColorArrays(topLeftSample.data, solidBlue)).toEqual(1);
+
+    // Take a sample of the bottom right corner and compare it to the expected
+    // solid green patch.
+    const bottomRightSample = ctx.getImageData(
+        Math.floor(copy.width - sampleWidth),
+        Math.floor(copy.height - sampleHeight),
+        sampleWidth,
+        sampleHeight,
+    );
+    expect(compareColorArrays(bottomRightSample.data, solidBlue)).toEqual(1);
+
+    // Lastly, sample a chunk of the middle of the image and compare it to the
+    // solid magenta patch.
+    const centerSample = ctx.getImageData(
+        Math.floor(copy.width * .5 - sampleWidth * .5),
+        Math.floor(copy.height * .5 - sampleHeight * .5),
+        sampleWidth,
+        sampleHeight,
+    );
+    expect(compareColorArrays(centerSample.data, solidYellow)).toEqual(1);
+
+    scene[SceneInternalSymbol].regl.destroy();
+  });
+});

--- a/test/glyph-integration.test.ts
+++ b/test/glyph-integration.test.ts
@@ -22,39 +22,19 @@ import {Scene} from '../src/lib/scene';
 import {SceneInternalSymbol} from '../src/lib/symbols';
 import {TimingFunctionsShim} from '../src/lib/timing-functions-shim';
 
-import {blobToImage, compareColorArrays, copyCanvasAndContainer, createSection, filledColorArray} from './utils';
+import {blobToImage, compareColorArrays, copyCanvasAndContainer, createArticle, createSection, filledColorArray} from './utils';
 
 /**
  * Tests produce visible artifacts for debugging.
  */
-const article = document.createElement('article');
-article.className = 'cw';
-article.innerHTML = `
-<style>
-.cw {
-  font-family: monospace;
-}
-.cw .content {
-  display: flex;
-  flex-direction: row;
-  flex-wrap: wrap;
-}
-.cw canvas {
-  background-image: linear-gradient(135deg, #aaa 50%, #ccc 50%);
-  background-size: 10px 10px;
-  box-shadow: inset 0 0 0 1px rgba(0,0,0,0.25);
-}
-</style>
-`;
+const article = createArticle();
 document.body.appendChild(article);
 
 describe('glyph', () => {
   it('should render a glyph of text', async () => {
     // Create a <section> for storing visible artifacts.
-    const section = createSection('glyph');
+    const {section, content} = createSection('glyph');
     article.appendChild(section);
-
-    const content = section.querySelector('.content')!;
 
     // Create a container <div> of fixed size for the Scene to render into.
     const container = document.createElement('div');

--- a/test/scene-integration.test.ts
+++ b/test/scene-integration.test.ts
@@ -554,7 +554,12 @@ describe('Scene', () => {
           const sprite = scene.createSprite();
           sprite.enter((s: SpriteView) => {
             s.BorderColorOpacity = .4;
-            s.BorderPlacement = 1;  // Place border outside shape.
+
+            // Place the border entirely outside the shape. It is only because
+            // of this that the bounding boxes of the sprites are large enough
+            // for the ensuing hitTest() invocations to hit them.
+            s.BorderPlacement = 1
+
             s.BorderRadiusPixel = 10;
             s.FillColor = [255, 255, 255, .4];
             s.PositionWorld = position;

--- a/test/scene-integration.test.ts
+++ b/test/scene-integration.test.ts
@@ -142,8 +142,8 @@ function makeGreenMagentaSquare(s: SpriteView) {
   // Border should be 1/4 of a world unit, half the radius of the
   // of the shape.
   s.BorderPlacement = 0;
-  s.BorderRadiusWorld = .25;
   s.BorderRadiusPixel = 0;
+  s.BorderRadiusRelative = .25;
 
   // Border is opaque green.
   s.BorderColorR = 0;

--- a/test/scene-integration.test.ts
+++ b/test/scene-integration.test.ts
@@ -123,6 +123,9 @@ function compareColorArrays(
   return matches / (expected.length / 4);
 }
 
+const GREEN = [0, 255, 0, 1];
+const MAGENTA = [255, 0, 255, 1];
+
 /**
  * Set a SpriteView's attributes to make the sprite a magenta filled square with
  * green border.
@@ -145,17 +148,8 @@ function makeGreenMagentaSquare(s: SpriteView) {
   s.BorderRadiusPixel = 0;
   s.BorderRadiusRelative = .25;
 
-  // Border is opaque green.
-  s.BorderColorR = 0;
-  s.BorderColorG = 255;
-  s.BorderColorB = 0;
-  s.BorderColorOpacity = 1;
-
-  // Interior fill is opaque magenta.
-  s.FillColorR = 255;
-  s.FillColorG = 0;
-  s.FillColorB = 255;
-  s.FillColorOpacity = 1;
+  s.BorderColor = GREEN;
+  s.FillColor = MAGENTA;
 }
 
 describe('Scene', () => {
@@ -560,11 +554,12 @@ describe('Scene', () => {
           const sprite = scene.createSprite();
           sprite.enter((s: SpriteView) => {
             s.BorderColorOpacity = .4;
+            s.BorderPlacement = 1;  // Place border outside shape.
             s.BorderRadiusPixel = 10;
             s.FillColor = [255, 255, 255, .4];
             s.PositionWorld = position;
             s.Sides = 1;
-            s.SizeWorld = .8;
+            s.SizeWorld = .5;
           })
           return sprite;
         });

--- a/test/sprite-integration.test.ts
+++ b/test/sprite-integration.test.ts
@@ -178,8 +178,8 @@ describe('Sprite', () => {
         // Border should be 1/4 of a world unit, half the radius of the
         // of the shape.
         s.BorderPlacement = 0;
-        s.BorderRadiusWorld = .25;
         s.BorderRadiusPixel = 0;
+        s.BorderRadiusRelative = .25;
 
         // Border is opaque green.
         s.BorderColorR = 0;
@@ -322,8 +322,8 @@ describe('Sprite', () => {
         // Border should be 1/4 of a world unit, half the radius of the
         // of the shape.
         s.BorderPlacement = 0;
-        s.BorderRadiusWorld = .25;
         s.BorderRadiusPixel = 0;
+        s.BorderRadiusRelative = .25;
 
         // Border is opaque, green.
         s.BorderColorR = 0;
@@ -528,8 +528,8 @@ describe('Sprite', () => {
             // Border should be 1/4 of a world unit, half the radius of the
             // of the shape.
             s.BorderPlacement = 0;
-            s.BorderRadiusWorld = .25;
             s.BorderRadiusPixel = 0;
+            s.BorderRadiusRelative = .25;
 
             // Border is solid green.
             s.BorderColorR = 0;

--- a/test/sprite-integration.test.ts
+++ b/test/sprite-integration.test.ts
@@ -519,15 +519,15 @@ describe('Sprite', () => {
             s.PositionWorldY = 0;
 
             // Sprite size should fill the canvas.
-            s.SizeWorldWidth = 1;
-            s.SizeWorldHeight = 1;
+            s.SizeWorldWidth = .8;
+            s.SizeWorldHeight = .8;
 
             // Shape should be a square to start.
             s.Sides = 2;
 
             // Border should be 1/4 of a world unit, half the radius of the
             // of the shape.
-            s.BorderPlacement = 0;
+            s.BorderPlacement = 1;
             s.BorderRadiusPixel = 0;
             s.BorderRadiusRelative = .25;
 

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -1,0 +1,94 @@
+/**
+ * @license
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * @fileoverview Utility functions used by tests.
+ */
+
+/**
+ * Create a <section> element inside the <article>.
+ */
+export function createSection(title: string): HTMLElement {
+  const section = document.createElement('section');
+  section.innerHTML = '<h2 class="title"></h2><div class="content"></div>';
+  section.querySelector('h2')!.textContent = title;
+  return section;
+}
+
+/**
+ * Create a canvas element with the same characteristics as the provided canvas.
+ * The copy will have the same size and styled size. Return the copy and its 2d
+ * context.
+ */
+export function copyCanvasAndContainer(canvas: HTMLCanvasElement):
+    [HTMLCanvasElement, CanvasRenderingContext2D, HTMLElement] {
+  const parent = canvas.parentElement!;
+  const div = document.createElement('div');
+  div.style.width = parent.style.width;
+  div.style.height = parent.style.height;
+  const copy = document.createElement('canvas');
+  copy.width = canvas.width;
+  copy.height = canvas.height;
+  copy.style.width = canvas.style.width;
+  copy.style.height = canvas.style.height;
+  const ctx = copy.getContext('2d')!;
+  div.appendChild(copy);
+  return [copy, ctx, div];
+}
+
+/**
+ * Render a blob to a canvas.
+ */
+export async function blobToImage(blob: Blob): Promise<HTMLImageElement> {
+  const url = URL.createObjectURL(blob);
+  const img = new Image();
+  const promise = new Promise<HTMLImageElement>((resolve, reject) => {
+    img.onload = () => resolve(img);
+    img.onerror = reject;
+  });
+  img.src = url;
+  return promise;
+}
+
+/**
+ * Given a target length, and the Uint 8 RGBA channels for a pixel, create a
+ * block of pixel values for testing sampled swatches of canvas data.
+ */
+export function filledColorArray(
+    pixelCount: number,
+    fillColor: [number, number, number, number]): Uint8ClampedArray {
+  const array = new Uint8ClampedArray(pixelCount * 4);
+  for (let i = 0; i < array.length; i++) {
+    array[i] = fillColor[i % fillColor.length];
+  }
+  return array;
+}
+
+/**
+ * Compare two color arrays and return the proportion of matching pixels.
+ */
+export function compareColorArrays(
+    actual: Uint8ClampedArray, expected: Uint8ClampedArray): number {
+  let matches = 0;
+  for (let i = 0; i < expected.length; i += 4) {
+    if (expected[i] === actual[i] && expected[i + 1] === actual[i + 1] &&
+        expected[i + 2] === actual[i + 2] &&
+        expected[i + 3] === actual[i + 3]) {
+      matches++;
+    }
+  }
+  return matches / (expected.length / 4);
+}

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -19,13 +19,51 @@
  */
 
 /**
+ * Create an <article> element to contain sections.
+ */
+export function createArticle() {
+  const article = document.createElement('article');
+  article.className = 'cw';
+
+  const css = `
+    .cw {
+      font-family: monospace;
+    }
+    .cw .content {
+      display: flex;
+      flex-direction: row;
+      flex-wrap: wrap;
+    }
+    .cw canvas {
+      background-image: linear-gradient(135deg, #aaa 50%, #ccc 50%);
+      background-size: 10px 10px;
+      box-shadow: inset 0 0 0 1px rgba(0,0,0,0.25);
+    }
+  `;
+
+  const style = document.createElement('style');
+  style.appendChild(document.createTextNode(css));
+  article.appendChild(style);
+
+  return article;
+}
+
+/**
  * Create a <section> element inside the <article>.
  */
-export function createSection(title: string): HTMLElement {
+export function createSection(title: string) {
   const section = document.createElement('section');
-  section.innerHTML = '<h2 class="title"></h2><div class="content"></div>';
-  section.querySelector('h2')!.textContent = title;
-  return section;
+
+  const header = document.createElement('h2');
+  header.className = 'title';
+  header.textContent = title;
+  section.appendChild(header);
+
+  const content = document.createElement('div');
+  content.className = 'content';
+  section.appendChild(content);
+
+  return {section, content};
 }
 
 /**


### PR DESCRIPTION
- Fixes #54
- Fixes #52
- Adds tests for BorderPlacement=1 to assert correct rendering.
- Fixes glyph rendering to match above changes.
- Adds integration test for glyph rendering.