### PR TITLE
Implement antialiasing

### DIFF
--- a/eslint.skipWords.txt
+++ b/eslint.skipWords.txt
@@ -1,5 +1,6 @@
 abcdefghijklmnopqrstuvwxyz
 accessor
+antialiasing
 bitwise
 broadcastable
 cancellable

--- a/eslint.skipWords.txt
+++ b/eslint.skipWords.txt
@@ -40,6 +40,7 @@ monospace
 mousemove
 minifiers
 ordinally
+pixelated
 readonly
 rebase
 rebasing

--- a/src/demo/debugging-demo.ts
+++ b/src/demo/debugging-demo.ts
@@ -26,6 +26,7 @@ import dat from 'dat.gui';
 import Stats from 'stats.js';
 
 import {Scene, SpriteView} from '../index';
+import {DEFAULT_SCENE_SETTINGS} from '../lib/default-scene-settings';
 import {InternalError} from '../lib/internal-error';
 import {SceneInternalSymbol} from '../lib/symbols';
 
@@ -81,6 +82,7 @@ function main() {
     inclusive: true,
     brush: false,
     clearBeforeUpdate: false,
+    antialiasingFactor: DEFAULT_SCENE_SETTINGS.antialiasingFactor,
     devicePixelRatio: window.devicePixelRatio || 1,
     pixelated: true,
     backgroundColor: '#001122',
@@ -98,6 +100,7 @@ function main() {
 
   // Create a Scene to be rendered in a fresh canvas fitted to container.
   const scene = new Scene({
+    antialiasingFactor: settings.antialiasingFactor,
     container,
     defaultTransitionTimeMs: 0,
     desiredSpriteCapacity: MAX_CAPACITY,
@@ -266,6 +269,10 @@ function main() {
   animationFolder.add(settings, 'clearBeforeUpdate');
 
   const systemFolder = gui.addFolder('system');
+  systemFolder.add(settings, 'antialiasingFactor', 0, 5, .01).onChange(() => {
+    scene[SceneInternalSymbol].antialiasingFactor = settings.antialiasingFactor;
+    scene[SceneInternalSymbol].queueDraw();
+  });
   systemFolder.add(settings, 'devicePixelRatio', 0.1, 2, .1).onChange(() => {
     scene.resize();
   });

--- a/src/demo/debugging-demo.ts
+++ b/src/demo/debugging-demo.ts
@@ -42,7 +42,6 @@ const MAX_CAPACITY = MAX_COUNT * MAX_COUNT;
  * every 10px and thick blue lines every 100px. Useful for estimating aspects of
  * rendered sprites like size and border width.
  */
-document.body.style.backgroundColor = '#012';
 document.body.style.backgroundImage = `
   url('data:image/svg+xml;base64,${btoa(`
     <svg xmlns="http://www.w3.org/2000/svg" height="100" width="100">
@@ -83,12 +82,16 @@ function main() {
     brush: false,
     clearBeforeUpdate: false,
     devicePixelRatio: window.devicePixelRatio || 1,
+    pixelated: true,
+    backgroundColor: '#001122',
     zoomX: true,
     zoomY: true,
     textBorder: '#ffffff',
     textFill: '#ff0000',
     textOpacity: 0.7,
   };
+
+  document.body.style.backgroundColor = settings.backgroundColor;
 
   // Locate the container element.
   const container = d3.select('body').node() as HTMLElement;
@@ -100,6 +103,8 @@ function main() {
     desiredSpriteCapacity: MAX_CAPACITY,
     devicePixelRatio: () => settings.devicePixelRatio,
   });
+
+  scene.canvas.style.imageRendering = settings.pixelated ? 'pixelated' : 'auto';
 
   const {workScheduler} = scene[SceneInternalSymbol];
 
@@ -266,6 +271,13 @@ function main() {
   });
   systemFolder.add(settings, 'zoomX');
   systemFolder.add(settings, 'zoomY');
+  systemFolder.add(settings, 'pixelated').onChange(() => {
+    scene.canvas.style.imageRendering =
+        settings.pixelated ? 'pixelated' : 'auto';
+  });
+  systemFolder.addColor(settings, 'backgroundColor').onChange(() => {
+    document.body.style.backgroundColor = settings.backgroundColor;
+  });
 
   const positionFolder = gui.addFolder('positioning');
   positionFolder.add(settings, 'paddingPx', -100, 100, 10).onChange(update);

--- a/src/lib/commands/setup-draw-command.ts
+++ b/src/lib/commands/setup-draw-command.ts
@@ -31,6 +31,7 @@ import {vertexShader} from '../shaders/scene-vertex-shader';
  * operate.
  */
 interface CoordinatorAPI {
+  antialiasingFactor: number;
   attributeMapper: AttributeMapper;
   canvas: HTMLCanvasElement;
   elapsedTimeMs: () => number;
@@ -111,6 +112,7 @@ export function setupDrawCommand(
 
     'uniforms': {
       'ts': () => coordinator.elapsedTimeMs(),
+      'antialiasingFactor': () => coordinator.antialiasingFactor,
       'devicePixelRatio': () => coordinator.getDevicePixelRatio(),
       'instanceCount': () => coordinator.instanceCount,
       'orderZGranularity': () => coordinator.orderZGranularity,

--- a/src/lib/default-scene-settings.ts
+++ b/src/lib/default-scene-settings.ts
@@ -33,6 +33,7 @@ export const DEFAULT_GLYPHS =
  * Parameters to configure the Scene.
  */
 export const DEFAULT_SCENE_SETTINGS: SceneSettings = Object.freeze({
+  antialiasingFactor: 0.5,
   container: document.body,
   defaultTransitionTimeMs: 250,
   desiredSpriteCapacity: 1e6,
@@ -46,6 +47,8 @@ export const DEFAULT_SCENE_SETTINGS: SceneSettings = Object.freeze({
 /**
  * Settings to configure a Scene.
  *
+ * @param {number} antialiasingFactor Radius in device pixels around which to
+ *     average border and fill color for antialiasing.
  * @param {HTMLElement} container Element into which regl will insert a canvas.
  * @param {number} defaultTransitionTimeMs Default duration of transitions in
  *     milliseconds. Defaults to 250ms, but can be made longer or shorter to
@@ -68,6 +71,7 @@ export const DEFAULT_SCENE_SETTINGS: SceneSettings = Object.freeze({
  * @param {TimingFunctions} timingFunctions Timing functions for WorkScheduler.
  */
 export interface SceneSettings {
+  antialiasingFactor: number;
   container: HTMLElement;
   defaultTransitionTimeMs: number;
   desiredSpriteCapacity: number;

--- a/src/lib/scene-internal.ts
+++ b/src/lib/scene-internal.ts
@@ -453,6 +453,12 @@ export class SceneInternal implements Renderer {
   private isViewInitialized = false;
 
   /**
+   * Defines the window radius for performing antialiasing in the fragment
+   * shader.
+   */
+  antialiasingFactor: number;
+
+  /**
    * Keep track of the devicePixelRatio used during the last initView() or
    * resize() call since it may change.
    */
@@ -499,6 +505,7 @@ export class SceneInternal implements Renderer {
       this.getDevicePixelRatio = () => devicePixelRatio;
     }
 
+    this.antialiasingFactor = settings.antialiasingFactor;
     this.container = settings.container;
     this.defaultTransitionTimeMs = settings.defaultTransitionTimeMs;
     this.orderZGranularity = settings.orderZGranularity;

--- a/src/lib/shaders/scene-fragment-shader.ts
+++ b/src/lib/shaders/scene-fragment-shader.ts
@@ -79,7 +79,7 @@ varying vec2 varyingVertexCoordinates;
 varying vec2 varyingBorderThresholds;
 
 /**
- * Scale value for converting edge distances to pixel distances is the fragment
+ * Scale value for converting edge distances to pixel distances in the fragment
  * shader.
  */
 varying float varyingEdgeToPixelScale;

--- a/src/lib/shaders/scene-fragment-shader.ts
+++ b/src/lib/shaders/scene-fragment-shader.ts
@@ -405,15 +405,26 @@ void main () {
   contrib /= width;
   contrib = clamp(contrib, 0., 1.);
 
-  // Combine border and fill color contributions to create final color.
-  vec4 color = contrib.x * varyingBorderColor + contrib.y * varyingFillColor;
+  // Mix alpha channels according to their absolute contributions.
+  float alpha =
+    contrib.x * varyingBorderColor.a +
+    contrib.y * varyingFillColor.a;
 
-  if (color.a < .01) {
+  // Discard low-alpha pixels so that sprites that are out of their natural
+  // order (due to OrderZ) are visible underneath higher sprites.
+  if (alpha < .01) {
     discard;
     return;
   }
 
-  gl_FragColor = color;
+  // Mix RGB channels of border and fill according to their relative
+  // contributions to the total.
+  float total = contrib.x + contrib.y;
+  vec3 color =
+    contrib.x / total * varyingBorderColor.rgb +
+    contrib.y / total * varyingFillColor.rgb;
+
+  gl_FragColor = vec4(color, alpha);
 }
 `;
 }

--- a/src/lib/shaders/scene-fragment-shader.ts
+++ b/src/lib/shaders/scene-fragment-shader.ts
@@ -60,6 +60,12 @@ uniform mat3 viewMatrix;
 uniform sampler2D sdfTexture;
 
 /**
+ * Antialiasing factor defines the window radius in device pixels to use to
+ * determine the contribution of border and fill colors for antialiasing.
+ */
+uniform float antialiasingFactor;
+
+/**
  * Varying time value, eased using cubic-in-out between the previous and target
  * timestamps for this Sprite.
  */
@@ -379,7 +385,8 @@ void main () {
 
   // Create an antialiasing window around the determined signed distance with
   // radius equal to 1 device pixel (diameter of 2 device pixels).
-  vec2 window = varyingEdgeToPixelScale * vec2(-1., 1.) + signedDistance;
+  vec2 window = signedDistance +
+    varyingEdgeToPixelScale * antialiasingFactor * vec2(-1., 1.);
 
   // Width of the antialiasing window.
   float width = window.y - window.x;

--- a/src/lib/shaders/scene-fragment-shader.ts
+++ b/src/lib/shaders/scene-fragment-shader.ts
@@ -394,18 +394,28 @@ void main () {
   // Determine the contribution to the window of the border and fill.
   vec2 contrib;
 
-  // Amount of space within the window that overlaps the border.
-  contrib.x =
-    min(varyingBorderThresholds.y, window.y) -
-    max(varyingBorderThresholds.x, window.x);
+  if (width > 0.) {
+    // Amount of space within the window that overlaps the border.
+    contrib.x =
+      min(varyingBorderThresholds.y, window.y) -
+      max(varyingBorderThresholds.x, window.x);
 
-  // Amount of space within the window that overlaps the fill color. May be
-  // negative, if no part of the window overlaps.
-  contrib.y = width - (varyingBorderThresholds.y - window.x);
+    // Amount of space within the window that overlaps the fill color. May be
+    // negative, if no part of the window overlaps.
+    contrib.y = width - (varyingBorderThresholds.y - window.x);
 
-  // Normalize contributions to the antialiasing window's width and clamp to
-  // possible contribution range.
-  contrib /= width;
+    // Normalize contributions to the antialiasing window's width and clamp to
+    // possible contribution range.
+    contrib /= width;
+  } else {
+    // If zero antialiasing, do a hard cutoff.
+    contrib.x = float(
+      varyingBorderThresholds.x <= signedDistance &&
+      signedDistance < varyingBorderThresholds.y
+    );
+    contrib.y = float(varyingBorderThresholds.y <= signedDistance);
+  }
+
   contrib = clamp(contrib, 0., 1.);
 
   // Mix alpha channels according to their absolute contributions.

--- a/src/lib/shaders/scene-fragment-shader.ts
+++ b/src/lib/shaders/scene-fragment-shader.ts
@@ -419,10 +419,8 @@ void main () {
 
   // Mix RGB channels of border and fill according to their relative
   // contributions to the total.
-  float total = contrib.x + contrib.y;
-  vec3 color =
-    contrib.x / total * varyingBorderColor.rgb +
-    contrib.y / total * varyingFillColor.rgb;
+  vec2 rel = contrib / (contrib.x + contrib.y);
+  vec3 color = rel.x * varyingBorderColor.rgb + rel.y * varyingFillColor.rgb;
 
   gl_FragColor = vec4(color, alpha);
 }

--- a/src/lib/shaders/scene-fragment-shader.ts
+++ b/src/lib/shaders/scene-fragment-shader.ts
@@ -32,7 +32,6 @@
  */
 
 import {glsl} from './glsl-template-tag';
-import * as ShaderFunctions from './shader-functions';
 
 /**
  * Returns the code for the Scene's main rendering fragment shader program.
@@ -107,9 +106,6 @@ varying float varyingPreviousSides;
 varying float varyingTargetSides;
 varying vec4 varyingPreviousShapeTexture;
 varying vec4 varyingTargetShapeTexture;
-
-// Import utility shader functions).
-${ShaderFunctions.range()}
 
 const float PI = 3.1415926535897932384626433832795;
 

--- a/src/lib/shaders/scene-fragment-shader.ts
+++ b/src/lib/shaders/scene-fragment-shader.ts
@@ -404,8 +404,7 @@ void main () {
     // negative, if no part of the window overlaps.
     contrib.y = width - (varyingBorderThresholds.y - window.x);
 
-    // Normalize contributions to the antialiasing window's width and clamp to
-    // possible contribution range.
+    // Normalize contributions to the antialiasing window's width.
     contrib /= width;
   } else {
     // If zero antialiasing, do a hard cutoff.
@@ -416,6 +415,7 @@ void main () {
     contrib.y = float(varyingBorderThresholds.y <= signedDistance);
   }
 
+  // Clamp contribution values to possible range.
   contrib = clamp(contrib, 0., 1.);
 
   // Mix alpha channels according to their absolute contributions.

--- a/src/lib/shaders/scene-vertex-shader.ts
+++ b/src/lib/shaders/scene-vertex-shader.ts
@@ -161,7 +161,7 @@ varying vec2 varyingVertexCoordinates;
 varying vec2 varyingBorderThresholds;
 
 /**
- * Scale value for converting edge distances to pixel distances is the fragment
+ * Scale value for converting edge distances to pixel distances in the fragment
  * shader.
  */
 varying float varyingEdgeToPixelScale;

--- a/src/lib/shaders/scene-vertex-shader.ts
+++ b/src/lib/shaders/scene-vertex-shader.ts
@@ -340,10 +340,8 @@ void main () {
   // of the shape. A point right on the edge of the shape will have a distance
   // of 0. In edge-distance space, a distance of 1 would be the dead center of a
   // circle.
-  float edgeDistance = currentBorderRadiusRelative + (
-    currentBorderRadiusPixel * varyingEdgeToPixelScale * devicePixelRatio
-  );
-
+  float edgeDistance = currentBorderRadiusRelative +
+    currentBorderRadiusPixel * varyingEdgeToPixelScale * devicePixelRatio;
   varyingBorderThresholds =
     vec2(0., edgeDistance) - edgeDistance * currentBorderPlacement;
 

--- a/test/scene-border-distance.test.ts
+++ b/test/scene-border-distance.test.ts
@@ -31,27 +31,31 @@ import {blobToImage, compareColorArrays, copyCanvasAndContainer, createArticle, 
 const article = createArticle();
 document.body.appendChild(article);
 
+const SAMPLE_WIDTH = 8;
+const SAMPLE_HEIGHT = 8;
+const SAMPLE_SIZE = SAMPLE_WIDTH * SAMPLE_HEIGHT;
+
 // Generate a blank patch and a solid cyan patch to compare to the rendered
 // pixels for correctness.
-const BLANK_PATCH = filledColorArray(100, [0, 0, 0, 0]);
-const CYAN_PATCH = filledColorArray(100, [0, 255, 255, 255]);
+const BLANK_PATCH = filledColorArray(SAMPLE_SIZE, [0, 0, 0, 0]);
+const CYAN_PATCH = filledColorArray(SAMPLE_SIZE, [0, 255, 255, 255]);
 
 // Grid of nine samples to test.
 const SAMPLES = [
   // Top row.
-  {position: [0, 0], expected: CYAN_PATCH},
-  {position: [25, 0], expected: CYAN_PATCH},
-  {position: [50, 0], expected: CYAN_PATCH},
+  {position: [1, 1], expected: CYAN_PATCH},
+  {position: [26, 1], expected: CYAN_PATCH},
+  {position: [51, 1], expected: CYAN_PATCH},
 
   // Middle row.
-  {position: [0, 25], expected: CYAN_PATCH},
-  {position: [25, 25], expected: BLANK_PATCH},
-  {position: [50, 25], expected: CYAN_PATCH},
+  {position: [1, 26], expected: CYAN_PATCH},
+  {position: [26, 26], expected: BLANK_PATCH},
+  {position: [51, 26], expected: CYAN_PATCH},
 
   // Bottom row.
-  {position: [0, 50], expected: CYAN_PATCH},
-  {position: [25, 50], expected: CYAN_PATCH},
-  {position: [50, 50], expected: CYAN_PATCH},
+  {position: [1, 51], expected: CYAN_PATCH},
+  {position: [26, 51], expected: CYAN_PATCH},
+  {position: [51, 51], expected: CYAN_PATCH},
 ];
 
 // Different scale values to apply, which should have no effect on rendering
@@ -132,7 +136,8 @@ describe('borders', () => {
         ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
 
         for (const {position: [x, y], expected} of SAMPLES) {
-          const sample = ctx.getImageData(x * dpr, y * dpr, 10, 10);
+          const sample =
+              ctx.getImageData(x * dpr, y * dpr, SAMPLE_WIDTH, SAMPLE_HEIGHT);
           expect(compareColorArrays(sample.data, expected)).toEqual(1);
         }
       }

--- a/test/scene-dpr.test.ts
+++ b/test/scene-dpr.test.ts
@@ -98,8 +98,8 @@ describe('Scene', () => {
         // Take a sample of the bottom right corner and compare it to the
         // expected solid green patch.
         const bottomRightSample = ctx.getImageData(
-            Math.floor(copy.width - sampleWidth - 2),
-            Math.floor(copy.height - sampleHeight - 2),
+            Math.floor(copy.width - sampleWidth - 1),
+            Math.floor(copy.height - sampleHeight - 1),
             sampleWidth,
             sampleHeight,
         );
@@ -117,8 +117,6 @@ describe('Scene', () => {
             sampleHeight,
         );
         expect(compareColorArrays(centerSample.data, magentaPatch)).toEqual(1);
-        /*/
-        //*/
 
         // Release REGL resources.
         scene[SceneInternalSymbol].regl.destroy();

--- a/test/scene-dpr.test.ts
+++ b/test/scene-dpr.test.ts
@@ -75,24 +75,21 @@ describe('Scene', () => {
         const img = await blobToImage(blob);
         ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
 
-        // For integration testing, we'll sample areas of the output that are
-        // 10% the width and height of the canvas size. This patch is a
+        // For integration testing, we'll sample areas of the output that are 5%
+        // the width and height of the canvas size. This patch is a
         // middle-ground between testing the whole image for pixel-perfect
         // rendering and testing a single pixel.
-        const sampleWidth = Math.ceil(copy.width * .1);
-        const sampleHeight = Math.ceil(copy.width * .1);
+        const sampleWidth = Math.ceil(copy.width * .05);
+        const sampleHeight = Math.ceil(copy.width * .05);
         const pixelCount = sampleWidth * sampleHeight;
 
-        // Generate patches of solid green and magenta to compare to the
-        // rendered pixels for correctness.
         const greenPatch = filledColorArray(pixelCount, [0, 255, 0, 255]);
-        const magentaPatch = filledColorArray(pixelCount, [255, 0, 255, 255]);
 
         // Take a sample of the top left corner and compare it to the expected
         // solid green patch.
         const topLeftSample = ctx.getImageData(
-            0,
-            0,
+            1,
+            1,
             sampleWidth,
             sampleHeight,
         );
@@ -101,13 +98,15 @@ describe('Scene', () => {
         // Take a sample of the bottom right corner and compare it to the
         // expected solid green patch.
         const bottomRightSample = ctx.getImageData(
-            Math.floor(copy.width - sampleWidth),
-            Math.floor(copy.height - sampleHeight),
+            Math.floor(copy.width - sampleWidth - 2),
+            Math.floor(copy.height - sampleHeight - 2),
             sampleWidth,
             sampleHeight,
         );
         expect(compareColorArrays(bottomRightSample.data, greenPatch))
             .toEqual(1);
+
+        const magentaPatch = filledColorArray(pixelCount, [255, 0, 255, 255]);
 
         // Lastly, sample a chunk of the middle of the image and compare it to
         // the solid magenta patch.
@@ -118,6 +117,8 @@ describe('Scene', () => {
             sampleHeight,
         );
         expect(compareColorArrays(centerSample.data, magentaPatch)).toEqual(1);
+        /*/
+        //*/
 
         // Release REGL resources.
         scene[SceneInternalSymbol].regl.destroy();

--- a/test/scene-initialization.test.ts
+++ b/test/scene-initialization.test.ts
@@ -82,16 +82,13 @@ describe('Scene', () => {
       const sampleHeight = Math.ceil(copy.width * .1);
       const pixelCount = sampleWidth * sampleHeight;
 
-      // Generate patches of solid green and magenta to compare to the
-      // rendered pixels for correctness.
       const greenPatch = filledColorArray(pixelCount, [0, 255, 0, 255]);
-      const magentaPatch = filledColorArray(pixelCount, [255, 0, 255, 255]);
 
       // Take a sample of the top left corner and compare it to the expected
       // solid green patch.
       const topLeftSample = ctx.getImageData(
-          0,
-          0,
+          1,
+          1,
           sampleWidth,
           sampleHeight,
       );
@@ -100,12 +97,14 @@ describe('Scene', () => {
       // Take a sample of the bottom right corner and compare it to the
       // expected solid green patch.
       const bottomRightSample = ctx.getImageData(
-          Math.floor(copy.width - sampleWidth),
-          Math.floor(copy.height - sampleHeight),
+          Math.floor(copy.width - sampleWidth - 1),
+          Math.floor(copy.height - sampleHeight - 1),
           sampleWidth,
           sampleHeight,
       );
       expect(compareColorArrays(bottomRightSample.data, greenPatch)).toEqual(1);
+
+      const magentaPatch = filledColorArray(pixelCount, [255, 0, 255, 255]);
 
       // Lastly, sample a chunk of the middle of the image and compare it to
       // the solid magenta patch.

--- a/test/scene-resize.test.ts
+++ b/test/scene-resize.test.ts
@@ -180,23 +180,24 @@ describe('Scene', () => {
       // Generate patches of solid green and magenta to compare to the rendered
       // pixels for correctness.
       const greenPatch = filledColorArray(pixelCount, [0, 255, 0, 255]);
-      const magentaPatch = filledColorArray(pixelCount, [255, 0, 255, 255]);
 
       // Take a sample of the top left corner and compare it to the expected
-      // solid green patch.
+      // solid green patch. Since antialiased pixels will have slightly
+      // different color values, we clip those from sampling.
       const topLeftSample = ctx.getImageData(
-          0,
-          0,
+          1,
+          1,
           sampleWidth,
           sampleHeight,
       );
       expect(compareColorArrays(topLeftSample.data, greenPatch)).toEqual(1);
 
+      const magentaPatch = filledColorArray(pixelCount, [255, 0, 255, 255]);
       // Take a sample of the bottom right corner and compare it to the expected
       // solid green patch.
       const bottomRightSample = ctx.getImageData(
-          Math.floor(copy.width - sampleWidth),
-          Math.floor(copy.height - sampleHeight),
+          Math.floor(copy.width - sampleWidth - 1),
+          Math.floor(copy.height - sampleHeight - 1),
           sampleWidth,
           sampleHeight,
       );

--- a/test/sprite-integration.test.ts
+++ b/test/sprite-integration.test.ts
@@ -140,12 +140,12 @@ describe('Sprite', () => {
       const img = await blobToImage(blob);
       ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
 
-      // For integration testing, we'll sample an area of the output that's 10%
+      // For integration testing, we'll sample an area of the output that's 5%
       // the width and height of the canvas size. This patch is a middle-ground
       // between testing the whole image for pixel-perfect rendering and testing
       // a single pixel.
-      const sampleWidth = Math.ceil(copy.width * .1);
-      const sampleHeight = Math.ceil(copy.width * .1);
+      const sampleWidth = Math.ceil(copy.width * .05);
+      const sampleHeight = Math.ceil(copy.width * .05);
       const pixelCount = sampleWidth * sampleHeight;
 
       // Generate patches of solid green and magenta to compare to the rendered
@@ -156,8 +156,8 @@ describe('Sprite', () => {
       // Take a sample of the top left corner and compare it to the expected
       // solid green patch.
       const topLeftSample = ctx.getImageData(
-          0,
-          0,
+          5,
+          5,
           sampleWidth,
           sampleHeight,
       );
@@ -166,8 +166,8 @@ describe('Sprite', () => {
       // Take a sample of the bottom right corner and compare it to the expected
       // solid green patch.
       const bottomRightSample = ctx.getImageData(
-          Math.floor(copy.width - sampleWidth),
-          Math.floor(copy.height - sampleHeight),
+          Math.floor(copy.width - sampleWidth - 5),
+          Math.floor(copy.height - sampleHeight - 5),
           sampleWidth,
           sampleHeight,
       );
@@ -341,12 +341,12 @@ describe('Sprite', () => {
       // the pixels of the final state to see if they match our expected
       // rendered pixels values.
 
-      // For integration testing, we'll sample an area of the output that's 10%
+      // For integration testing, we'll sample an area of the output that's 5%
       // the width and height of the canvas size. This patch is a middle-ground
       // between testing the whole image for pixel-perfect rendering and testing
       // a single pixel.
-      const sampleWidth = Math.ceil(copy.width * .1);
-      const sampleHeight = Math.ceil(copy.width * .1);
+      const sampleWidth = Math.ceil(copy.width * .05);
+      const sampleHeight = Math.ceil(copy.width * .05);
       const pixelCount = sampleWidth * sampleHeight;
 
       // Define solid blue and yellow samples for comparison.
@@ -356,7 +356,7 @@ describe('Sprite', () => {
       // Take a sample from the middle top of the circle (blue border).
       const topCenterSample = ctx.getImageData(
           Math.floor(copy.width * .5 - sampleWidth * .5),
-          0,
+          1,
           sampleWidth,
           sampleHeight,
       );
@@ -364,7 +364,7 @@ describe('Sprite', () => {
 
       const bottomCenterSample = ctx.getImageData(
           Math.floor(copy.width * .5 - sampleWidth * .5),
-          Math.floor(copy.height - sampleHeight),
+          Math.floor(copy.height - sampleHeight - 1),
           sampleWidth,
           sampleHeight,
       );
@@ -615,12 +615,12 @@ describe('Sprite', () => {
       const img = await blobToImage(blob);
       ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
 
-      // For integration testing, we'll sample an area of the output that's 10%
+      // For integration testing, we'll sample an area of the output that's 5%
       // the width and height of the canvas size. This patch is a middle-ground
       // between testing the whole image for pixel-perfect rendering and testing
       // a single pixel.
-      const sampleWidth = Math.ceil(copy.width * .1);
-      const sampleHeight = Math.ceil(copy.width * .1);
+      const sampleWidth = Math.ceil(copy.width * .05);
+      const sampleHeight = Math.ceil(copy.width * .05);
       const pixelCount = sampleWidth * sampleHeight;
 
       // Generate patches of solid green and magenta to compare to the rendered
@@ -631,8 +631,8 @@ describe('Sprite', () => {
       // Take a sample of the top left corner and compare it to the expected
       // solid green patch.
       const topLeftSample = ctx.getImageData(
-          0,
-          0,
+          5,
+          5,
           sampleWidth,
           sampleHeight,
       );
@@ -641,8 +641,8 @@ describe('Sprite', () => {
       // Take a sample of the bottom right corner and compare it to the expected
       // solid green patch.
       const bottomRightSample = ctx.getImageData(
-          Math.floor(copy.width - sampleWidth),
-          Math.floor(copy.height - sampleHeight),
+          Math.floor(copy.width - sampleWidth - 5),
+          Math.floor(copy.height - sampleHeight - 5),
           sampleWidth,
           sampleHeight,
       );


### PR DESCRIPTION
Fixes #79 

Before:

<img width="502" alt="Screen Shot 2022-10-20 at 1 15 58 PM" src="https://user-images.githubusercontent.com/71617/197027083-f815e47c-cd12-4670-9f26-6da37bd73a5e.png">

After:

<img width="502" alt="Screen Shot 2022-10-20 at 1 18 14 PM" src="https://user-images.githubusercontent.com/71617/197027108-44422d39-8f2d-4662-883a-263475249e25.png">

The above images use a synthetic `devicePixelRatio` of 0.1 so that it takes 10 logical pixels to fill 1 synthetic device pixel. 

They also have artificially set the canvas's [`image-rendering`](https://developer.mozilla.org/en-US/docs/Web/CSS/image-rendering) attribute to `pixelated`. Without this, the browser would soften the rendered canvas image with bilinear resampling.